### PR TITLE
로컬에서 간단하게 쓸 postgres 데이터베이스

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  postgres:
+    image: postgres:15
+    restart: always
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
현재 작업중인 개발 컴퓨터에서 postgres 데이터베이스를 컨테이너로 가져와 실행시키는
docker-compose.yml 파일입니다. 

docker-compose.yml 파일이있는 위치 ( 8term-coko-back/docker-compose.yml ) 에서 
`docker-compose up` 명령어를 치면 postgres 컨테이너가 실행됩니다.
8term-coko-back / postgres-data 디렉토리에 컨테이너의 데이터가 저장되서 컨테이너가 꺼져도 자료가 남아있습니다.
`docker-compose up` 실행시 자동으로 8term-coko-back / postgres-data 디렉토리가 생성되지만
혹시 8term-coko-back / postgres-data 가 없다면 만들어 주시면 됩니다. 

postgres 접근은 `localhost:5432` 입니다.

POSTGRES_USER: postgres
POSTGRES_PASSWORD: postgres
POSTGRES_DB: postgres

도 참고하시면 되겠습니다. 컴포즈 안에 내용이 있습니다.


## 🔍 변경 사항

- [x] docker-compose.yml 파일 생성됨
- [x] `docker-compose up` 로 실행
- [x] `localhost:5432`  포트 확인

## 💬리뷰 요구사항 (선택사항)