### PR TITLE
User Swagger 문서 생성

### DIFF
--- a/prisma/migrations/20241021064303_/migration.sql
+++ b/prisma/migrations/20241021064303_/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Users` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "Users";
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "nickname" VARCHAR(50) NOT NULL,
+    "profile_image" TEXT,
+    "max_health_point" INTEGER NOT NULL DEFAULT 5,
+    "last_login" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "level" INTEGER NOT NULL DEFAULT 1,
+    "experience" INTEGER NOT NULL DEFAULT 0,
+    "experience_for_next_level" INTEGER NOT NULL DEFAULT 50,
+    "point" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Sections {
 }
 
 
-model Users{
+model User{
   id Int @id @default(autoincrement())
   createdAt DateTime @default(now())      @map("created_at")
   updatedAt DateTime @updatedAt           @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,16 +13,18 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Users{
+model users{
   id Int @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  nickname String @db.VarChar(50)
-  profileImage String?
-  maxHealthPoint Int @default(5)
-  lastLogin DateTime @default(now())
-  level Int @default(1)
+  createdAt DateTime @default(now())      @map("created_at")
+  updatedAt DateTime @updatedAt           @map("updated_at")
+  nickname String @db.VarChar(50)         
+  profileImage String?                    @map("profile_image")
+  maxHealthPoint Int @default(5)          @map("max_health_point")
+  lastLogin DateTime @default(now())      @map("last_login")
+  level Int @default(1) 
   experience Int @default(0)
-  experienceForNextLevel Int @default(50)
+  experienceForNextLevel Int @default(50) @map("experience_for_next_level")
   point Int @default(0)
+
+  @@map("users")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model users{
+model Users{
   id Int @id @default(autoincrement())
   createdAt DateTime @default(now())      @map("created_at")
   updatedAt DateTime @updatedAt           @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,10 +5,9 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
-
 
 datasource db {
   provider = "postgresql"
@@ -18,56 +17,55 @@ datasource db {
 enum Part {
   EASY
   NORMAL
-  HARD 
+  HARD
   VERY_HARD
 }
 
 enum Category {
-  COMBINATION 
+  COMBINATION
   MULTIPLE_CHOICE
   OX_SELECTOR
   SHORT_ANSWER
 }
 
 model Quizzes {
-  id              Int      @id @default(autoincrement())
-  part            Part
-  sectionId       Int      @map("section_id")
-  title           String   @db.VarChar(255)	
-  question        String   @db.VarChar(1000)	
-  answer          String[]
-  answerChoice    String[] @map("answer_choice")
-  category        Category
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt      @map("updated_at")
-  section         Sections @relation(fields: [sectionId], references: [id])
+  id           Int      @id @default(autoincrement())
+  part         Part
+  sectionId    Int      @map("section_id")
+  title        String   @db.VarChar(255)
+  question     String   @db.VarChar(1000)
+  answer       String[]
+  answerChoice String[] @map("answer_choice")
+  category     Category
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+  section      Sections @relation(fields: [sectionId], references: [id])
 
   @@map("quizzes")
 }
 
 model Sections {
-  id              Int      @id @default(autoincrement())
-  name            String   @unique   @db.VarChar(255)	
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt      @map("updated_at")
-  quizzes         Quizzes[]
+  id        Int       @id @default(autoincrement())
+  name      String    @unique @db.VarChar(255)
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  quizzes   Quizzes[]
 
   @@map("sections")
 }
 
-
-model User{
-  id Int @id @default(autoincrement())
-  createdAt DateTime @default(now())      @map("created_at")
-  updatedAt DateTime @updatedAt           @map("updated_at")
-  nickname String @db.VarChar(50)         
-  profileImage String?                    @map("profile_image")
-  maxHealthPoint Int @default(5)          @map("max_health_point")
-  lastLogin DateTime @default(now())      @map("last_login")
-  level Int @default(1) 
-  experience Int @default(0)
-  experienceForNextLevel Int @default(50) @map("experience_for_next_level")
-  point Int @default(0)
+model User {
+  id                     Int      @id @default(autoincrement())
+  createdAt              DateTime @default(now()) @map("created_at")
+  updatedAt              DateTime @updatedAt @map("updated_at")
+  nickname               String   @db.VarChar(50)
+  profileImage           String?  @map("profile_image")
+  maxHealthPoint         Int      @default(5) @map("max_health_point")
+  lastLogin              DateTime @default(now()) @map("last_login")
+  level                  Int      @default(1)
+  experience             Int      @default(0)
+  experienceForNextLevel Int      @default(50) @map("experience_for_next_level")
+  point                  Int      @default(0)
 
   @@map("users")
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,11 +15,24 @@ async function bootstrap() {
   );
 
   const config = new DocumentBuilder()
-    .setTitle('Median')
-    .setDescription('The Median API description')
-    .setVersion('0.1')
+    .setTitle('Coko API')
+    .setDescription('Coko API 문서입니다.')
+    .setVersion('1.0')
+    .addTag('users', 'users 관련 API')
+    .addTag('point', 'point 관련 API')
+    .addTag('experience', 'experience 관련 API')
+    .setTermsOfService('https://modern-agile-official-client.vercel.app/') // 설명 링크 첨부하면 됨
+    .setContact(
+      '백엔드 팀',
+      'https://github.com/modern-agile-team/8term-coko-back',
+      'yja208501@gmail.com',
+    )
+    .setLicense(
+      'MIT',
+      'https://github.com/git/git-scm.com/blob/gh-pages/MIT-LICENSE.txt',
+    )
+    .addServer('http://localhost:3000/', 'develop')
     .build();
-
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 

--- a/src/users/controllers/user-experience.controller.ts
+++ b/src/users/controllers/user-experience.controller.ts
@@ -8,7 +8,9 @@ import {
 } from '@nestjs/common';
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { UserExperienceService } from '../services/user-experience.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('experience')
 @Controller('users/:id/experience')
 export class UserExperienceController {
   constructor(private readonly experienceService: UserExperienceService) {}

--- a/src/users/controllers/user-experience.controller.ts
+++ b/src/users/controllers/user-experience.controller.ts
@@ -9,6 +9,8 @@ import {
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { UserExperienceService } from '../services/user-experience.service';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiGetExperience } from '../swagger-dacorator/get-user-experience-decorators';
+import { ApiUpdateExperience } from '../swagger-dacorator/patch-user-experience-decorators';
 
 @ApiTags('experience')
 @Controller('users/:id/experience')
@@ -16,11 +18,13 @@ export class UserExperienceController {
   constructor(private readonly experienceService: UserExperienceService) {}
 
   @Get()
+  @ApiGetExperience()
   getUserExperience(@Param('id', ParseIntPipe) userId: number) {
     return this.experienceService.getUserExperience(userId);
   }
 
   @Patch()
+  @ApiUpdateExperience()
   updateExperience(
     @Param('id', ParseIntPipe) userId: number,
     @Body() updateExperienceData: UpdateExperienceDto,

--- a/src/users/controllers/user-experience.controller.ts
+++ b/src/users/controllers/user-experience.controller.ts
@@ -1,16 +1,10 @@
-import {
-  Controller,
-  Get,
-  Body,
-  Patch,
-  Param,
-  ParseIntPipe,
-} from '@nestjs/common';
+import { Controller, Get, Body, Patch, Param } from '@nestjs/common';
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { UserExperienceService } from '../services/user-experience.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiGetExperience } from '../swagger-dacorator/get-user-experience-decorators';
 import { ApiUpdateExperience } from '../swagger-dacorator/patch-user-experience-decorators';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 
 @ApiTags('experience')
 @Controller('users/:id/experience')
@@ -19,14 +13,14 @@ export class UserExperienceController {
 
   @Get()
   @ApiGetExperience()
-  getUserExperience(@Param('id', ParseIntPipe) userId: number) {
+  getUserExperience(@Param('id', PositiveIntPipe) userId: number) {
     return this.experienceService.getUserExperience(userId);
   }
 
   @Patch()
   @ApiUpdateExperience()
   updateExperience(
-    @Param('id', ParseIntPipe) userId: number,
+    @Param('id', PositiveIntPipe) userId: number,
     @Body() updateExperienceData: UpdateExperienceDto,
   ) {
     return this.experienceService.updateExperience(

--- a/src/users/controllers/user-point.controller.ts
+++ b/src/users/controllers/user-point.controller.ts
@@ -8,12 +8,9 @@ import {
 } from '@nestjs/common';
 import { UserPointService } from '../services/user-point.service';
 import { UpdatePointDto } from '../dtos/update-point.dto';
-import {
-  ApiOkResponse,
-  ApiOperation,
-  ApiResponse,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiUpdatePoint } from '../swagger-dacorator/patch-user-point-decorators';
+import { ApiGetPoint } from '../swagger-dacorator/get-user-point-decorators';
 
 @ApiTags('point')
 @Controller('users/:id/point')
@@ -21,22 +18,13 @@ export class UserPointController {
   constructor(private readonly pointsService: UserPointService) {}
 
   @Get()
+  @ApiGetPoint()
   getUserPoint(@Param('id', ParseIntPipe) userId: number) {
     return this.pointsService.getUserPoint(userId);
   }
 
   @Patch()
-  @ApiOkResponse({ description: '성공적으로 포인트가 수정됨' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
-  @ApiOperation({
-    summary: '포인트 증감 수정',
-    description: ` ## 포인트 증감 수정
-    0 포인트 밑으로 수정되지 않음`,
-    externalDocs: {
-      description: 'nest 공식 문서',
-      url: 'https://docs.nestjs.com',
-    },
-  })
+  @ApiUpdatePoint()
   update(
     @Param('id', ParseIntPipe) userId: number,
     @Body() updatePointData: UpdatePointDto,

--- a/src/users/controllers/user-point.controller.ts
+++ b/src/users/controllers/user-point.controller.ts
@@ -8,7 +8,14 @@ import {
 } from '@nestjs/common';
 import { UserPointService } from '../services/user-point.service';
 import { UpdatePointDto } from '../dtos/update-point.dto';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('point')
 @Controller('users/:id/point')
 export class UserPointController {
   constructor(private readonly pointsService: UserPointService) {}
@@ -19,6 +26,17 @@ export class UserPointController {
   }
 
   @Patch()
+  @ApiOkResponse({ description: '성공적으로 포인트가 수정됨' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiOperation({
+    summary: '포인트 증감 수정',
+    description: ` ## 포인트 증감 수정
+    0 포인트 밑으로 수정되지 않음`,
+    externalDocs: {
+      description: 'nest 공식 문서',
+      url: 'https://docs.nestjs.com',
+    },
+  })
   update(
     @Param('id', ParseIntPipe) userId: number,
     @Body() updatePointData: UpdatePointDto,

--- a/src/users/controllers/user-point.controller.ts
+++ b/src/users/controllers/user-point.controller.ts
@@ -1,16 +1,10 @@
-import {
-  Controller,
-  Get,
-  Body,
-  Patch,
-  Param,
-  ParseIntPipe,
-} from '@nestjs/common';
+import { Controller, Get, Body, Patch, Param } from '@nestjs/common';
 import { UserPointService } from '../services/user-point.service';
 import { UpdatePointDto } from '../dtos/update-point.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiUpdatePoint } from '../swagger-dacorator/patch-user-point-decorators';
 import { ApiGetPoint } from '../swagger-dacorator/get-user-point-decorators';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 
 @ApiTags('point')
 @Controller('users/:id/point')
@@ -19,14 +13,14 @@ export class UserPointController {
 
   @Get()
   @ApiGetPoint()
-  getUserPoint(@Param('id', ParseIntPipe) userId: number) {
+  getUserPoint(@Param('id', PositiveIntPipe) userId: number) {
     return this.pointsService.getUserPoint(userId);
   }
 
   @Patch()
   @ApiUpdatePoint()
   update(
-    @Param('id', ParseIntPipe) userId: number,
+    @Param('id', PositiveIntPipe) userId: number,
     @Body() updatePointData: UpdatePointDto,
   ) {
     return this.pointsService.updatePoint(userId, updatePointData);

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -17,6 +17,9 @@ import { UpdateUserDto } from '../dtos/update-user.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiGetAllUsers } from '../swagger-dacorator/get-all-users-decorators';
 import { ApiGetUser } from '../swagger-dacorator/get-user-decorators';
+import { ApiUpdateUser } from '../swagger-dacorator/patch-user-decorators';
+import { ApiCreateUser } from '../swagger-dacorator/post-user-decorators';
+import { ApiDeleteUser } from '../swagger-dacorator/delete-user-decorators';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @ApiTags('users')
@@ -36,11 +39,13 @@ export class UsersController {
     return this.usersService.getUser(userId);
   }
 
+  @ApiCreateUser()
   @Post()
   createUser(@Body() createUserData: CreateUserDto): Promise<ResponseUserDto> {
     return this.usersService.createUser(createUserData);
   }
 
+  @ApiUpdateUser()
   @Patch(':id')
   updateUser(
     @Param('id', ParseIntPipe) userId: number,
@@ -49,6 +54,7 @@ export class UsersController {
     return this.usersService.updateUser(userId, updateUserData);
   }
 
+  @ApiDeleteUser()
   @Delete(':id')
   remove(@Param('id', ParseIntPipe) userId: number) {
     this.usersService.deleteUser(userId);

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -14,8 +14,10 @@ import { UsersService } from '../services/users.service';
 import { CreateUserDto } from '../dtos/create-user.dto';
 import { ResponseUserDto } from '../dtos/response-user.dto';
 import { UpdateUserDto } from '../dtos/update-user.dto';
+import { ApiTags } from '@nestjs/swagger';
 
 @UseInterceptors(ClassSerializerInterceptor)
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -15,6 +15,8 @@ import { CreateUserDto } from '../dtos/create-user.dto';
 import { ResponseUserDto } from '../dtos/response-user.dto';
 import { UpdateUserDto } from '../dtos/update-user.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiGetAllUsers } from '../swagger-dacorator/get-all-users-decorators';
+import { ApiGetUser } from '../swagger-dacorator/get-user-decorators';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @ApiTags('users')
@@ -22,11 +24,13 @@ import { ApiTags } from '@nestjs/swagger';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
+  @ApiGetAllUsers()
   @Get()
   getAllUsers() {
     return this.usersService.getAllUsers();
   }
 
+  @ApiGetUser()
   @Get(':id')
   getUser(@Param('id', ParseIntPipe) userId: number) {
     return this.usersService.getUser(userId);

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -5,7 +5,6 @@ import {
   Delete,
   Get,
   Param,
-  ParseIntPipe,
   Patch,
   Post,
   UseInterceptors,
@@ -20,6 +19,7 @@ import { ApiGetUser } from '../swagger-dacorator/get-user-decorators';
 import { ApiUpdateUser } from '../swagger-dacorator/patch-user-decorators';
 import { ApiCreateUser } from '../swagger-dacorator/post-user-decorators';
 import { ApiDeleteUser } from '../swagger-dacorator/delete-user-decorators';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @ApiTags('users')
@@ -35,7 +35,7 @@ export class UsersController {
 
   @ApiGetUser()
   @Get(':id')
-  getUser(@Param('id', ParseIntPipe) userId: number) {
+  getUser(@Param('id', PositiveIntPipe) userId: number) {
     return this.usersService.getUser(userId);
   }
 
@@ -48,7 +48,7 @@ export class UsersController {
   @ApiUpdateUser()
   @Patch(':id')
   updateUser(
-    @Param('id', ParseIntPipe) userId: number,
+    @Param('id', PositiveIntPipe) userId: number,
     @Body() updateUserData: UpdateUserDto,
   ): Promise<ResponseUserDto> {
     return this.usersService.updateUser(userId, updateUserData);
@@ -56,7 +56,7 @@ export class UsersController {
 
   @ApiDeleteUser()
   @Delete(':id')
-  remove(@Param('id', ParseIntPipe) userId: number) {
+  remove(@Param('id', PositiveIntPipe) userId: number) {
     this.usersService.deleteUser(userId);
     return { statusCode: 204, message: 'No Content' };
   }

--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -1,9 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
 
 export class CreateUserDto {
+  @ApiProperty({
+    required: true,
+    type: String,
+    description: '유저 닉네임',
+    example: 'gwgw99',
+    default: 'nickname',
+    minimum: 2,
+    maximum: 10,
+  })
   @IsString()
   readonly nickname: string;
 
+  @ApiProperty({
+    type: String,
+    description: '유저 프로필 이미지지',
+    example: 'imageurl.jpg',
+    default: 'imageurl',
+  })
   @IsOptional()
   @IsString()
   readonly profileImage?: string;

--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -17,8 +17,8 @@ export class CreateUserDto {
   @ApiProperty({
     type: String,
     description: '유저 프로필 이미지지',
-    example: 'imageurl.jpg',
-    default: 'imageurl',
+    example: 'image.jpg',
+    default: 'image',
   })
   @IsOptional()
   @IsString()

--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, Length } from 'class-validator';
 
 export class CreateUserDto {
   @ApiProperty({
@@ -7,18 +7,17 @@ export class CreateUserDto {
     type: String,
     description: '유저 닉네임',
     example: 'gwgw99',
-    default: 'nickname',
     minimum: 2,
     maximum: 10,
   })
   @IsString()
+  @Length(2, 10)
   readonly nickname: string;
 
   @ApiProperty({
     type: String,
     description: '유저 프로필 이미지지',
     example: 'image.jpg',
-    default: 'image',
   })
   @IsOptional()
   @IsString()

--- a/src/users/dtos/response-experience.dto.ts
+++ b/src/users/dtos/response-experience.dto.ts
@@ -1,4 +1,4 @@
-import { users } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 export class ResponseExperienceDto {
   readonly id: number;
@@ -7,7 +7,7 @@ export class ResponseExperienceDto {
   readonly experience: number;
   readonly experienceForNextLevel: number;
 
-  constructor(user: users) {
+  constructor(user: Users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.level = user.level;

--- a/src/users/dtos/response-experience.dto.ts
+++ b/src/users/dtos/response-experience.dto.ts
@@ -1,4 +1,4 @@
-import { Users } from '@prisma/client';
+import { users } from '@prisma/client';
 
 export class ResponseExperienceDto {
   readonly id: number;
@@ -7,7 +7,7 @@ export class ResponseExperienceDto {
   readonly experience: number;
   readonly experienceForNextLevel: number;
 
-  constructor(user: Users) {
+  constructor(user: users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.level = user.level;

--- a/src/users/dtos/response-experience.dto.ts
+++ b/src/users/dtos/response-experience.dto.ts
@@ -1,4 +1,4 @@
-import { Users } from '@prisma/client';
+import { User } from '@prisma/client';
 
 export class ResponseExperienceDto {
   readonly id: number;
@@ -7,7 +7,7 @@ export class ResponseExperienceDto {
   readonly experience: number;
   readonly experienceForNextLevel: number;
 
-  constructor(user: Users) {
+  constructor(user: User) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.level = user.level;

--- a/src/users/dtos/response-point.dto.ts
+++ b/src/users/dtos/response-point.dto.ts
@@ -1,11 +1,11 @@
-import { users } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 export class ResponsePointDto {
   readonly id: number;
   readonly nickname?: string;
   readonly point: number;
 
-  constructor(user: users) {
+  constructor(user: Users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.point = user.point;

--- a/src/users/dtos/response-point.dto.ts
+++ b/src/users/dtos/response-point.dto.ts
@@ -1,11 +1,11 @@
-import { Users } from '@prisma/client';
+import { User } from '@prisma/client';
 
 export class ResponsePointDto {
   readonly id: number;
   readonly nickname?: string;
   readonly point: number;
 
-  constructor(user: Users) {
+  constructor(user: User) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.point = user.point;

--- a/src/users/dtos/response-point.dto.ts
+++ b/src/users/dtos/response-point.dto.ts
@@ -1,11 +1,11 @@
-import { Users } from '@prisma/client';
+import { users } from '@prisma/client';
 
 export class ResponsePointDto {
   readonly id: number;
   readonly nickname?: string;
   readonly point: number;
 
-  constructor(user: Users) {
+  constructor(user: users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.point = user.point;

--- a/src/users/dtos/response-user.dto.ts
+++ b/src/users/dtos/response-user.dto.ts
@@ -1,4 +1,4 @@
-import { users } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 export class ResponseUserDto {
   readonly id: number;
@@ -10,7 +10,7 @@ export class ResponseUserDto {
   readonly experienceForNextLevel: number;
   readonly point: number;
 
-  constructor(user: users) {
+  constructor(user: Users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.profileImage = user.profileImage;

--- a/src/users/dtos/response-user.dto.ts
+++ b/src/users/dtos/response-user.dto.ts
@@ -1,4 +1,4 @@
-import { Users } from '@prisma/client';
+import { users } from '@prisma/client';
 
 export class ResponseUserDto {
   readonly id: number;
@@ -10,7 +10,7 @@ export class ResponseUserDto {
   readonly experienceForNextLevel: number;
   readonly point: number;
 
-  constructor(user: Users) {
+  constructor(user: users) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.profileImage = user.profileImage;

--- a/src/users/dtos/response-user.dto.ts
+++ b/src/users/dtos/response-user.dto.ts
@@ -1,4 +1,4 @@
-import { Users } from '@prisma/client';
+import { User } from '@prisma/client';
 
 export class ResponseUserDto {
   readonly id: number;
@@ -10,7 +10,7 @@ export class ResponseUserDto {
   readonly experienceForNextLevel: number;
   readonly point: number;
 
-  constructor(user: Users) {
+  constructor(user: User) {
     this.id = user.id;
     this.nickname = user.nickname;
     this.profileImage = user.profileImage;

--- a/src/users/dtos/update-experience.dto.ts
+++ b/src/users/dtos/update-experience.dto.ts
@@ -1,10 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdateExperienceDto {
+  @ApiProperty({
+    type: String,
+    description: '유저 닉네임',
+    example: 'gwgw123',
+    default: 'nickname',
+    minimum: 2,
+    maximum: 10,
+  })
   @IsOptional()
   @IsString()
   readonly nickname?: string;
 
+  @ApiProperty({
+    required: true,
+    type: Number,
+    description: '경험치 증가치',
+    example: 30,
+    default: 30,
+  })
   @IsNumber()
   readonly experience: number;
 }

--- a/src/users/dtos/update-experience.dto.ts
+++ b/src/users/dtos/update-experience.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
 
 export class UpdateExperienceDto {
   @ApiProperty({
@@ -22,5 +22,6 @@ export class UpdateExperienceDto {
     default: 30,
   })
   @IsNumber()
+  @Min(0)
   readonly experience: number;
 }

--- a/src/users/dtos/update-experience.dto.ts
+++ b/src/users/dtos/update-experience.dto.ts
@@ -1,17 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsNumber, IsOptional, IsString, Length, Min } from 'class-validator';
 
 export class UpdateExperienceDto {
   @ApiProperty({
     type: String,
     description: '유저 닉네임',
     example: 'gwgw123',
-    default: 'nickname',
     minimum: 2,
     maximum: 10,
   })
   @IsOptional()
   @IsString()
+  @Length(2, 10)
   readonly nickname?: string;
 
   @ApiProperty({
@@ -19,7 +19,6 @@ export class UpdateExperienceDto {
     type: Number,
     description: '경험치 증가치',
     example: 30,
-    default: 30,
   })
   @IsNumber()
   @Min(0)

--- a/src/users/dtos/update-point.dto.ts
+++ b/src/users/dtos/update-point.dto.ts
@@ -1,10 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdatePointDto {
+  @ApiProperty({
+    required: false,
+    type: String,
+    description: '유저 닉네임',
+    example: 'gwgw123',
+    default: 'nickname',
+    minimum: 2,
+    maximum: 20,
+  })
   @IsOptional()
   @IsString()
   readonly nickname?: string;
 
+  @ApiProperty({
+    required: true,
+    type: Number,
+    description: '포인트 증감치',
+    example: 30,
+    default: 30,
+  })
   @IsNumber()
   readonly point: number;
 }

--- a/src/users/dtos/update-point.dto.ts
+++ b/src/users/dtos/update-point.dto.ts
@@ -3,13 +3,12 @@ import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdatePointDto {
   @ApiProperty({
-    required: false,
     type: String,
     description: '유저 닉네임',
     example: 'gwgw123',
     default: 'nickname',
     minimum: 2,
-    maximum: 20,
+    maximum: 10,
   })
   @IsOptional()
   @IsString()

--- a/src/users/dtos/update-point.dto.ts
+++ b/src/users/dtos/update-point.dto.ts
@@ -1,17 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsOptional, IsString, Length } from 'class-validator';
 
 export class UpdatePointDto {
   @ApiProperty({
     type: String,
     description: '유저 닉네임',
     example: 'gwgw123',
-    default: 'nickname',
     minimum: 2,
     maximum: 10,
   })
   @IsOptional()
   @IsString()
+  @Length(2, 10)
   readonly nickname?: string;
 
   @ApiProperty({
@@ -19,8 +19,7 @@ export class UpdatePointDto {
     type: Number,
     description: '포인트 증감치',
     example: 30,
-    default: 30,
   })
-  @IsNumber()
+  @IsInt()
   readonly point: number;
 }

--- a/src/users/dtos/update-user.dto.ts
+++ b/src/users/dtos/update-user.dto.ts
@@ -1,12 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional } from 'class-validator';
+import { IsInt, IsNumber, IsOptional } from 'class-validator';
 
 export class UpdateUserDto {
   @ApiProperty({
     type: Number,
     description: '유저 경험치',
     example: 200,
-    default: 0,
   })
   @IsOptional()
   @IsNumber()
@@ -16,9 +15,8 @@ export class UpdateUserDto {
     type: Number,
     description: '유저 포인트',
     example: 300,
-    default: 0,
   })
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   readonly point?: number;
 }

--- a/src/users/dtos/update-user.dto.ts
+++ b/src/users/dtos/update-user.dto.ts
@@ -1,10 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsOptional } from 'class-validator';
 
 export class UpdateUserDto {
+  @ApiProperty({
+    type: Number,
+    description: '유저 경험치',
+    example: 200,
+    default: 0,
+  })
   @IsOptional()
   @IsNumber()
   readonly experience?: number;
 
+  @ApiProperty({
+    type: Number,
+    description: '유저 포인트',
+    example: 300,
+    default: 0,
+  })
   @IsOptional()
   @IsNumber()
   readonly point?: number;

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -21,7 +21,7 @@ export class UserExperienceService {
     });
 
     if (!userExperience) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
     return new ResponseExperienceDto(userExperience);
   }
@@ -33,10 +33,10 @@ export class UserExperienceService {
     const user = await this.prisma.users.findUnique({ where: { id } });
 
     if (!user) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
     if (updateExperienceData.experience < 0) {
-      throw new BadRequestException('Experience points cannot be negative');
+      throw new BadRequestException('experience points cannot be negative');
     }
 
     const { userLevel, userExperience, experienceForNextLevel } =

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ResponseExperienceDto } from '../dtos/response-experience.dto';
@@ -30,6 +34,9 @@ export class UserExperienceService {
 
     if (!user) {
       throw new NotFoundException(`ID ${id} not found`);
+    }
+    if (updateExperienceData.experience < 0) {
+      throw new BadRequestException('Experience points cannot be negative');
     }
 
     const { userLevel, userExperience, experienceForNextLevel } =

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -35,9 +35,6 @@ export class UserExperienceService {
     if (!user) {
       throw new NotFoundException(`id ${id} not found`);
     }
-    if (updateExperienceData.experience < 0) {
-      throw new BadRequestException('experience points cannot be negative');
-    }
 
     const { userLevel, userExperience, experienceForNextLevel } =
       this.calculateLevel(

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ResponseExperienceDto } from '../dtos/response-experience.dto';
@@ -16,7 +12,7 @@ export class UserExperienceService {
   constructor(private prisma: PrismaService) {}
 
   async getUserExperience(id: number): Promise<ResponseExperienceDto> {
-    const userExperience = await this.prisma.users.findUnique({
+    const userExperience = await this.prisma.user.findUnique({
       where: { id },
     });
 
@@ -30,7 +26,7 @@ export class UserExperienceService {
     id: number,
     updateExperienceData: UpdateExperienceDto,
   ): Promise<ResponseExperienceDto> {
-    const user = await this.prisma.users.findUnique({ where: { id } });
+    const user = await this.prisma.user.findUnique({ where: { id } });
 
     if (!user) {
       throw new NotFoundException(`id ${id} not found`);
@@ -44,7 +40,7 @@ export class UserExperienceService {
         updateExperienceData.experience,
       );
 
-    const updatedExperience = await this.prisma.users.update({
+    const updatedExperience = await this.prisma.user.update({
       where: { id },
       data: {
         level: userLevel,

--- a/src/users/services/user-point.service.ts
+++ b/src/users/services/user-point.service.ts
@@ -12,7 +12,7 @@ export class UserPointService {
   constructor(private prisma: PrismaService) {}
 
   async getUserPoint(id: number): Promise<ResponsePointDto> {
-    const userPoint = await this.prisma.users.findUnique({
+    const userPoint = await this.prisma.user.findUnique({
       where: { id },
     });
     if (!userPoint) {
@@ -25,14 +25,14 @@ export class UserPointService {
     id: number,
     updatePointData: UpdatePointDto,
   ): Promise<ResponsePointDto> {
-    const user = await this.prisma.users.findUnique({ where: { id } });
+    const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) {
       throw new NotFoundException(`id ${id} not found`);
     } else if (0 > user.point + updatePointData.point) {
       throw new BadRequestException('user points are not enough');
     }
 
-    const userPoint = await this.prisma.users.update({
+    const userPoint = await this.prisma.user.update({
       where: { id },
       data: { point: { increment: updatePointData.point } },
     });

--- a/src/users/services/user-point.service.ts
+++ b/src/users/services/user-point.service.ts
@@ -16,7 +16,7 @@ export class UserPointService {
       where: { id },
     });
     if (!userPoint) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
     return new ResponsePointDto(userPoint);
   }
@@ -27,9 +27,9 @@ export class UserPointService {
   ): Promise<ResponsePointDto> {
     const user = await this.prisma.users.findUnique({ where: { id } });
     if (!user) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     } else if (0 > user.point + updatePointData.point) {
-      throw new BadRequestException('User points are not enough');
+      throw new BadRequestException('user points are not enough');
     }
 
     const userPoint = await this.prisma.users.update({

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -9,11 +9,11 @@ export class UsersService {
   constructor(private prisma: PrismaService) {}
 
   getAllUsers(): Promise<ResponseUserDto[]> {
-    return this.prisma.users.findMany();
+    return this.prisma.user.findMany();
   }
 
   async getUser(id: number): Promise<ResponseUserDto> {
-    const userResponse = await this.prisma.users.findUnique({ where: { id } });
+    const userResponse = await this.prisma.user.findUnique({ where: { id } });
     if (!userResponse) {
       throw new NotFoundException(`id ${id} not found`);
     }
@@ -21,7 +21,7 @@ export class UsersService {
   }
 
   async createUser(createUserData: CreateUserDto): Promise<ResponseUserDto> {
-    const userResponse = await this.prisma.users.create({
+    const userResponse = await this.prisma.user.create({
       data: createUserData,
     });
     return new ResponseUserDto(userResponse);
@@ -31,11 +31,11 @@ export class UsersService {
     id: number,
     updateUserData: UpdateUserDto,
   ): Promise<ResponseUserDto> {
-    if (!(await this.prisma.users.findUnique({ where: { id } }))) {
+    if (!(await this.prisma.user.findUnique({ where: { id } }))) {
       throw new NotFoundException(`id ${id} not found`);
     }
 
-    const userResponse = await this.prisma.users.update({
+    const userResponse = await this.prisma.user.update({
       where: { id },
       data: updateUserData,
     });
@@ -43,9 +43,9 @@ export class UsersService {
   }
 
   async deleteUser(id: number): Promise<void> {
-    if (!(await this.prisma.users.findUnique({ where: { id } }))) {
+    if (!(await this.prisma.user.findUnique({ where: { id } }))) {
       throw new NotFoundException(`id ${id} not found`);
     }
-    await this.prisma.users.delete({ where: { id } });
+    await this.prisma.user.delete({ where: { id } });
   }
 }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -15,7 +15,7 @@ export class UsersService {
   async getUser(id: number): Promise<ResponseUserDto> {
     const userResponse = await this.prisma.users.findUnique({ where: { id } });
     if (!userResponse) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
     return new ResponseUserDto(userResponse);
   }
@@ -32,7 +32,7 @@ export class UsersService {
     updateUserData: UpdateUserDto,
   ): Promise<ResponseUserDto> {
     if (!(await this.prisma.users.findUnique({ where: { id } }))) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
 
     const userResponse = await this.prisma.users.update({
@@ -44,7 +44,7 @@ export class UsersService {
 
   async deleteUser(id: number): Promise<void> {
     if (!(await this.prisma.users.findUnique({ where: { id } }))) {
-      throw new NotFoundException(`ID ${id} not found`);
+      throw new NotFoundException(`id ${id} not found`);
     }
     await this.prisma.users.delete({ where: { id } });
   }

--- a/src/users/swagger-dacorator/delete-user-decorators.ts
+++ b/src/users/swagger-dacorator/delete-user-decorators.ts
@@ -21,7 +21,7 @@ export function ApiDeleteUser() {
     }),
     ApiResponse({
       status: 400,
-      description: '요청 데이터 타입이 일치하지 않을 경우 (id)',
+      description: 'id 요청 데이터 타입이 일치하지 않을 경우',
       content: {
         JSON: {
           example: {
@@ -38,7 +38,7 @@ export function ApiDeleteUser() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/delete-user-decorators.ts
+++ b/src/users/swagger-dacorator/delete-user-decorators.ts
@@ -1,0 +1,49 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiDeleteUser() {
+  return applyDecorators(
+    ApiOperation({
+      summary: ' 유저 삭제',
+      description: ` ## 유저 삭제`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 유저가 삭제 된 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 204,
+            message: 'No Content',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '요청 데이터 타입이 일치하지 않을 경우 (id)',
+      content: {
+        JSON: {
+          example: {
+            message: 'Validation failed (numeric string is expected)',
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/get-all-users-decorators.ts
+++ b/src/users/swagger-dacorator/get-all-users-decorators.ts
@@ -4,7 +4,7 @@ import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 export function ApiGetAllUsers() {
   return applyDecorators(
     ApiOperation({
-      summary: '전체 유저 정보 조회',
+      summary: '전체 유저 조회',
       description: `## 전체 유저 조회`,
     }),
     ApiResponse({

--- a/src/users/swagger-dacorator/get-all-users-decorators.ts
+++ b/src/users/swagger-dacorator/get-all-users-decorators.ts
@@ -1,0 +1,60 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGetAllUsers() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '전체 유저 정보 조회',
+      description: `## 전체 유저 조회`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 전체 유저가 조회된 경우',
+      content: {
+        JSON: {
+          example: [
+            {
+              id: 2,
+              createdAt: '2024-10-14T06:33:20.072Z',
+              updatedAt: '2024-10-14T06:33:20.072Z',
+              nickname: 'gwgw2',
+              profileImage: null,
+              maxHealthPoint: 5,
+              lastLogin: '2024-10-14T06:33:20.072Z',
+              level: 1,
+              experience: 30,
+              experienceForNextLevel: 50,
+              point: 200,
+            },
+            {
+              id: 3,
+              createdAt: '2024-10-14T08:56:25.726Z',
+              updatedAt: '2024-10-14T08:56:25.726Z',
+              nickname: 'gwgwgw3',
+              profileImage: null,
+              maxHealthPoint: 5,
+              lastLogin: '2024-10-14T08:56:25.726Z',
+              level: 2,
+              experience: 20,
+              experienceForNextLevel: 60,
+              point: 5000,
+            },
+            {
+              id: 4,
+              createdAt: '2024-10-14T09:09:57.505Z',
+              updatedAt: '2024-10-14T09:09:57.505Z',
+              nickname: 'gwgwgwgw4',
+              profileImage: null,
+              maxHealthPoint: 5,
+              lastLogin: '2024-10-14T09:09:57.505Z',
+              level: 1,
+              experience: 0,
+              experienceForNextLevel: 50,
+              point: 160,
+            },
+          ],
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/get-user-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-decorators.ts
@@ -1,0 +1,55 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGetUser() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '단일 유저 정보 조회',
+      description: `## 단일 유저 정보 조회`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 단일 유저가 조회된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 2,
+            nickname: 'gwgw123',
+            profileImage: null,
+            maxHealthPoint: 5,
+            level: 2,
+            experience: 30,
+            experienceForNextLevel: 60,
+            point: 200,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      content: {
+        JSON: {
+          example: {
+            message: 'Validation failed (numeric string is expected)',
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/get-user-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-decorators.ts
@@ -4,8 +4,8 @@ import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 export function ApiGetUser() {
   return applyDecorators(
     ApiOperation({
-      summary: '단일 유저 정보 조회',
-      description: `## 단일 유저 정보 조회`,
+      summary: '단일 유저 조회',
+      description: `## 단일 유저 조회`,
     }),
     ApiResponse({
       status: 200,
@@ -27,7 +27,7 @@ export function ApiGetUser() {
     }),
     ApiResponse({
       status: 400,
-      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      description: 'id 요청 데이터 타입이 일치하지 않을 경우',
       content: {
         JSON: {
           example: {
@@ -44,7 +44,7 @@ export function ApiGetUser() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/get-user-experience-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-experience-decorators.ts
@@ -1,0 +1,52 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGetExperience() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '경험치 조회',
+      description: `## 경험치 조회`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 포인트가 조회된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 15,
+            nickname: 'gwgw123',
+            level: 1,
+            experience: 30,
+            experienceForNextLevel: 50,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      content: {
+        JSON: {
+          example: {
+            message: 'Validation failed (numeric string is expected)',
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/get-user-experience-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-experience-decorators.ts
@@ -24,7 +24,7 @@ export function ApiGetExperience() {
     }),
     ApiResponse({
       status: 400,
-      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      description: 'id 요청 데이터 타입이 일치하지 않을 경우',
       content: {
         JSON: {
           example: {
@@ -41,7 +41,7 @@ export function ApiGetExperience() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/get-user-point-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-point-decorators.ts
@@ -1,0 +1,50 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGetPoint() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '포인트 조회',
+      description: `## 포인트 조회`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 포인트가 조회된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 15,
+            nickname: 'gwgw123',
+            point: 70,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      content: {
+        JSON: {
+          example: {
+            message: 'Validation failed (numeric string is expected)',
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/get-user-point-decorators.ts
+++ b/src/users/swagger-dacorator/get-user-point-decorators.ts
@@ -22,7 +22,7 @@ export function ApiGetPoint() {
     }),
     ApiResponse({
       status: 400,
-      description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+      description: 'id 요청 데이터 타입이 일치하지 않을 경우',
       content: {
         JSON: {
           example: {
@@ -39,7 +39,7 @@ export function ApiGetPoint() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/patch-user-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-decorators.ts
@@ -1,0 +1,60 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiUpdateUser() {
+  return applyDecorators(
+    ApiOperation({
+      summary: ' 유저 정보 수정',
+      description: ` ## 유저 정보 수정`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 유저 정보가 수정된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 15,
+            nickname: 'gwgw123',
+            profileImage: null,
+            maxHealthPoint: 5,
+            level: 4,
+            experience: 500,
+            experienceForNextLevel: 86,
+            point: 200,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description:
+        '요청 데이터 타입이 일치하지 않을 경우 (id, point, experience)',
+      content: {
+        JSON: {
+          example: {
+            value: {
+              message: [
+                'point must be a number conforming to the specified constraints',
+              ],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/patch-user-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-decorators.ts
@@ -4,8 +4,8 @@ import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 export function ApiUpdateUser() {
   return applyDecorators(
     ApiOperation({
-      summary: ' 유저 정보 수정',
-      description: ` ## 유저 정보 수정`,
+      summary: ' 유저 수정',
+      description: ` ## 유저 수정`,
     }),
     ApiResponse({
       status: 200,
@@ -27,17 +27,29 @@ export function ApiUpdateUser() {
     }),
     ApiResponse({
       status: 400,
-      description:
-        '요청 데이터 타입이 일치하지 않을 경우 (id, point, experience)',
+      description: '400 errors',
       content: {
         JSON: {
-          example: {
-            value: {
-              message: [
-                'point must be a number conforming to the specified constraints',
-              ],
-              error: 'Bad Request',
-              statusCode: 400,
+          examples: {
+            'id type mismatch': {
+              value: {
+                message: 'Validation failed (numeric string is expected)',
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: 'id 요청 데이터 타입이 일치하지 않을 경우',
+            },
+            'experience, point type mismatch': {
+              value: {
+                message: [
+                  'experience must be a number conforming to the specified constraints',
+                  'point must be a number conforming to the specified constraints',
+                ],
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description:
+                'experience, point 요청 데이터 타입이 일치하지 않을 경우',
             },
           },
         },
@@ -49,7 +61,7 @@ export function ApiUpdateUser() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/patch-user-experience-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-experience-decorators.ts
@@ -24,19 +24,19 @@ export function ApiUpdateExperience() {
     }),
     ApiResponse({
       status: 400,
-      description: '400 error',
+      description: '400 errors',
       content: {
         JSON: {
           examples: {
-            'Bad Request': {
+            'id type mismatch': {
               value: {
-                message: 'Experience points cannot be negative',
+                message: 'Validation failed (numeric string is expected)',
                 error: 'Bad Request',
                 statusCode: 400,
               },
-              description: '경험치 값이 음수인 경우',
+              description: 'id 요청 데이터 타입이 일치하지 않을 경우',
             },
-            'type mismatch': {
+            'experience type mismatch': {
               value: {
                 message: [
                   'experience must be a number conforming to the specified constraints',
@@ -44,7 +44,15 @@ export function ApiUpdateExperience() {
                 error: 'Bad Request',
                 statusCode: 400,
               },
-              description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+              description: 'experience 요청 데이터 타입이 일치하지 않을 경우',
+            },
+            'Bad Request': {
+              value: {
+                message: ['experience must not be less than 0'],
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '경험치 값이 음수인 경우',
             },
           },
         },
@@ -56,7 +64,7 @@ export function ApiUpdateExperience() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/patch-user-experience-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-experience-decorators.ts
@@ -1,0 +1,67 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiUpdateExperience() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '경험치 증가 수정',
+      description: ` ## 경험치 증가 수정`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 경험치가 수정된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 15,
+            nickname: 'gwgw123',
+            level: 1,
+            experience: 30,
+            experienceForNextLevel: 50,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '400 error',
+      content: {
+        JSON: {
+          examples: {
+            'not enough points': {
+              value: {
+                message: 'user points are not enough',
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '포인트가 부족한 경우',
+            },
+            'type mismatch': {
+              value: {
+                message: [
+                  'experience must be a number conforming to the specified constraints',
+                ],
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/patch-user-experience-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-experience-decorators.ts
@@ -28,13 +28,13 @@ export function ApiUpdateExperience() {
       content: {
         JSON: {
           examples: {
-            'not enough points': {
+            'Bad Request': {
               value: {
-                message: 'user points are not enough',
+                message: 'Experience points cannot be negative',
                 error: 'Bad Request',
                 statusCode: 400,
               },
-              description: '포인트가 부족한 경우',
+              description: '경험치 값이 음수인 경우',
             },
             'type mismatch': {
               value: {

--- a/src/users/swagger-dacorator/patch-user-point-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-point-decorators.ts
@@ -23,19 +23,19 @@ export function ApiUpdatePoint() {
     }),
     ApiResponse({
       status: 400,
-      description: '400 error',
+      description: '400 errors',
       content: {
         JSON: {
           examples: {
-            'not enough points': {
+            'id type mismatch': {
               value: {
-                message: 'user points are not enough',
+                message: 'Validation failed (numeric string is expected)',
                 error: 'Bad Request',
                 statusCode: 400,
               },
-              description: '포인트가 부족한 경우',
+              description: 'id 요청 데이터 타입이 일치하지 않을 경우',
             },
-            'type mismatch': {
+            'point type mismatch': {
               value: {
                 message: [
                   'point must be a number conforming to the specified constraints',
@@ -43,7 +43,15 @@ export function ApiUpdatePoint() {
                 error: 'Bad Request',
                 statusCode: 400,
               },
-              description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+              description: 'point 요청 데이터 타입이 일치하지 않을 경우',
+            },
+            'not enough points': {
+              value: {
+                message: 'user points are not enough',
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '포인트가 부족한 경우',
             },
           },
         },
@@ -55,7 +63,7 @@ export function ApiUpdatePoint() {
       content: {
         JSON: {
           example: {
-            message: 'ID 999 not found',
+            message: 'id 999 not found',
             error: 'Not Found',
             statusCode: 404,
           },

--- a/src/users/swagger-dacorator/patch-user-point-decorators.ts
+++ b/src/users/swagger-dacorator/patch-user-point-decorators.ts
@@ -1,0 +1,66 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiUpdatePoint() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '포인트 증감 수정',
+      description: ` ## 포인트 증감 수정
+    0 포인트 밑으로 수정되지 않음`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 포인트가 수정된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 15,
+            nickname: 'gwgw123',
+            point: 70,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '400 error',
+      content: {
+        JSON: {
+          examples: {
+            'not enough points': {
+              value: {
+                message: 'user points are not enough',
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '포인트가 부족한 경우',
+            },
+            'type mismatch': {
+              value: {
+                message: [
+                  'point must be a number conforming to the specified constraints',
+                ],
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+              description: '요청 데이터 타입이 일치하지 않을 경우 (문자열 등)',
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'id를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: 'ID 999 not found',
+            error: 'Not Found',
+            statusCode: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/users/swagger-dacorator/post-user-decorators.ts
+++ b/src/users/swagger-dacorator/post-user-decorators.ts
@@ -15,7 +15,7 @@ export function ApiCreateUser() {
           example: {
             id: 99,
             nickname: 'gwgw99',
-            profileImage: null,
+            profileImage: 'image.jpg',
             maxHealthPoint: 5,
             level: 1,
             experience: 0,
@@ -27,7 +27,7 @@ export function ApiCreateUser() {
     }),
     ApiResponse({
       status: 400,
-      description: '요청 데이터 타입이 일치하지 않을 경우 (nickname)',
+      description: 'nickname 요청 데이터 타입이 일치하지 않을 경우',
       content: {
         JSON: {
           example: {

--- a/src/users/swagger-dacorator/post-user-decorators.ts
+++ b/src/users/swagger-dacorator/post-user-decorators.ts
@@ -1,0 +1,46 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiCreateUser() {
+  return applyDecorators(
+    ApiOperation({
+      summary: ' 유저 추가',
+      description: ` ## 유저 추가`,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 유저가 추가 된 경우',
+      content: {
+        JSON: {
+          example: {
+            id: 99,
+            nickname: 'gwgw99',
+            profileImage: null,
+            maxHealthPoint: 5,
+            level: 1,
+            experience: 0,
+            experienceForNextLevel: 50,
+            point: 0,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '요청 데이터 타입이 일치하지 않을 경우 (nickname)',
+      content: {
+        JSON: {
+          example: {
+            value: {
+              message: {
+                message: ['nickname must be a string'],
+                error: 'Bad Request',
+                statusCode: 400,
+              },
+            },
+          },
+        },
+      },
+    }),
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈
#16 

## 📝작업 내용
- **Swagger 의존성 설치** 후 main.ts 파일에 전체적인 Swagger document 세팅
→ Swagger로 사용할 **URI, 태그들, 버전, 라이센스** 등 을 설정함
- 각 요청 DTO에 **@ApiProperty**를 작성
→ Swagger 페이지에서 **Schemas 의 DTO 정보**를 알려줌
- 컨트롤러에서 각 요청 정보 세팅했는데 컨트롤러 코드가 너무 길어지기 때문에 
**Swagger 데코레이터 파일로 분리** 시켰음
→ 이는 **각 요청의 정보**를 알려줌 ( 어떤 요청인지, 상황별 요청의 응답이 어떻게 되는지,
content에 **상태코드, 응답 데이터**들이 담겨있음) 

## 🔍 변경 사항

- Swagger 문서를 작성했습니다
-  `http://localhost:3000/api` 에서 Swagger 문서를 확인할 수 있습니다 
```
// main.ts

SwaggerModule.setup('api', app, document);
```
경로 설정 부분입니다

## 💬리뷰 요구사항 (선택사항)
