### PR TITLE
1. sections quizzes parts progress API들 swagger 설정 +  2. sections, parts의 외래키 참조 무결성 제약 변경

### DIFF
--- a/prisma/migrations/20241107020106_relationship_parts_delete/migration.sql
+++ b/prisma/migrations/20241107020106_relationship_parts_delete/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "parts" DROP CONSTRAINT "parts_section_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "quizzes" DROP CONSTRAINT "quizzes_part_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_part_id_fkey" FOREIGN KEY ("part_id") REFERENCES "parts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "parts" ADD CONSTRAINT "parts_section_id_fkey" FOREIGN KEY ("section_id") REFERENCES "sections"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20241107021017_delete_relationship_change_restrict/migration.sql
+++ b/prisma/migrations/20241107021017_delete_relationship_change_restrict/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "parts" DROP CONSTRAINT "parts_section_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "quizzes" DROP CONSTRAINT "quizzes_part_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_part_id_fkey" FOREIGN KEY ("part_id") REFERENCES "parts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "parts" ADD CONSTRAINT "parts_section_id_fkey" FOREIGN KEY ("section_id") REFERENCES "sections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model Quiz {
   category     Category
   createdAt    DateTime   @default(now()) @map("created_at")
   updatedAt    DateTime   @updatedAt @map("updated_at")
-  part         Part       @relation(fields: [partId], references: [id])
+  part         Part       @relation(fields: [partId], references: [id], onDelete: Cascade)
   progress     Progress[]
 
   @@map("quizzes")
@@ -83,7 +83,7 @@ model Part {
   name      String   @unique @db.VarChar(255)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  section   Section  @relation(fields: [sectionId], references: [id])
+  section   Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
   quiz      Quiz[]
 
   @@map("parts")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model Quiz {
   category     Category
   createdAt    DateTime   @default(now()) @map("created_at")
   updatedAt    DateTime   @updatedAt @map("updated_at")
-  part         Part       @relation(fields: [partId], references: [id], onDelete: Cascade)
+  part         Part       @relation(fields: [partId], references: [id], onDelete: Restrict)
   progress     Progress[]
 
   @@map("quizzes")
@@ -83,7 +83,7 @@ model Part {
   name      String   @unique @db.VarChar(255)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  section   Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  section   Section  @relation(fields: [sectionId], references: [id], onDelete: Restrict)
   quiz      Quiz[]
 
   @@map("parts")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,6 @@ import { PartsModule } from './parts/parts.module';
     PartsModule,
   ],
   controllers: [AppController],
-  providers: [AppService, PrismaService],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/src/parts/dto/create-part.dto.ts
+++ b/src/parts/dto/create-part.dto.ts
@@ -1,6 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, Min } from 'class-validator';
 
 export class CreatePartDto {
+  @ApiProperty({
+    required: true,
+    description: '섹션 id',
+    example: 1,
+  })
   @IsInt()
   @Min(0)
   readonly sectionId: number;

--- a/src/parts/parts.controller.ts
+++ b/src/parts/parts.controller.ts
@@ -10,7 +10,9 @@ import {
 import { PartsService } from './parts.service';
 import { CreatePartDto } from './dto/create-part.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('parts')
 @Controller('parts')
 export class PartsController {
   constructor(private readonly partsService: PartsService) {}

--- a/src/parts/parts.controller.ts
+++ b/src/parts/parts.controller.ts
@@ -1,32 +1,28 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
 import { PartsService } from './parts.service';
 import { CreatePartDto } from './dto/create-part.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiParts } from './parts.swagger';
 
 @ApiTags('parts')
 @Controller('parts')
 export class PartsController {
   constructor(private readonly partsService: PartsService) {}
 
+  @ApiParts.create()
   @Post()
   create(@Body() partData: CreatePartDto) {
     return this.partsService.create(partData);
   }
 
+  @ApiParts.findAll()
   @Get()
   findAll() {
     return this.partsService.findAll();
   }
 
+  @ApiParts.remove()
   @Delete(':id')
   remove(@Param('id', PositiveIntPipe) id: number) {
     return this.partsService.remove(id);

--- a/src/parts/parts.service.ts
+++ b/src/parts/parts.service.ts
@@ -53,6 +53,16 @@ export class PartsService {
       throw new NotFoundException();
     }
 
+    const quiz = await this.prisma.quiz.findMany({
+      where: {
+        partId: id,
+      },
+    });
+
+    if (quiz.length) {
+      throw new ConflictException('파트를 참조하고 있는 문제데이터가 있음');
+    }
+
     return this.prisma.part.delete({
       where: {
         id,

--- a/src/parts/parts.swagger.ts
+++ b/src/parts/parts.swagger.ts
@@ -1,0 +1,151 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const ApiParts = {
+  create: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 생성',
+      }),
+      ApiResponse({
+        status: 201,
+        description: 'sections가 성공적으로 생성됨',
+        content: {
+          JSON: {
+            example: {
+              id: 2,
+              name: 'JSON',
+              createdAt: '2024-11-04T10:42:17.052Z',
+              updatedAt: '2024-11-04T10:42:17.052Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'name이 string 이 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['name must be a string'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '사용하지 않는 속성을 body에 넣은듯 (ex: "test: 2")',
+        content: {
+          JSON: {
+            example: {
+              message: [
+                'property test should not exist',
+                'name must be a string',
+              ],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '문제파트의 종류 전체 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '파트의 id, 상위섹션 id, 파트의 name을 전체 조회함',
+        content: {
+          JSON: {
+            example: [
+              {
+                id: 1,
+                sectionId: 1,
+                name: 'argument',
+                createdAt: '2024-10-31T08:31:03.580Z',
+                updatedAt: '2024-10-31T08:31:03.580Z',
+              },
+            ],
+          },
+        },
+      }),
+    );
+  },
+  remove: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '문제파트 단일 삭제',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '특정 파트의 id param값을 통해 단일 파트 삭제',
+        content: {
+          JSON: {
+            example: {
+              id: 1,
+              sectionId: 1,
+              name: 'argument',
+              createdAt: '2024-10-31T08:31:03.580Z',
+              updatedAt: '2024-10-31T08:31:03.580Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '파트의 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '파트의 id 값이 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '파트의 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 409,
+        description: '파트를 참조하고 있는 문제가 있어 삭제를 거부함',
+        content: {
+          JSON: {
+            example: {
+              message: '파트를 참조하고 있는 문제데이터가 있음',
+              error: 'Conflict',
+              statusCode: 409,
+            },
+          },
+        },
+      }),
+    );
+  },
+};

--- a/src/progress/dto/create-progress.dto.ts
+++ b/src/progress/dto/create-progress.dto.ts
@@ -1,6 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsNumber, IsString } from 'class-validator';
 
 export class CreateProgressDto {
+  @ApiProperty({
+    required: true,
+    description: '유저가 정답을 맞췄는지 여부 , 맞췄을 시 true',
+    example: false,
+  })
   @IsBoolean()
   readonly isCorrect: boolean;
 }

--- a/src/progress/dto/query-progress.dto.ts
+++ b/src/progress/dto/query-progress.dto.ts
@@ -1,13 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Min } from 'class-validator';
 
 export class QueryProgressDto {
+  @ApiProperty({
+    description: '자연수 section id 입력',
+    example: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(0)
   readonly sectionId?: number;
 
+  @ApiProperty({
+    description: '자연수 part id 입력',
+    example: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/src/progress/progress.controller.ts
+++ b/src/progress/progress.controller.ts
@@ -4,12 +4,14 @@ import { CreateProgressDto } from './dto/create-progress.dto';
 import { QueryProgressDto } from './dto/query-progress.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiProgress } from './progress.swagger';
 
 @ApiTags('progress')
 @Controller('users/:id/progress')
 export class ProgressController {
   constructor(private readonly progressService: ProgressService) {}
 
+  @ApiProgress.findAll()
   @Get()
   findAll(
     @Param('id', PositiveIntPipe) userId: number,
@@ -18,8 +20,9 @@ export class ProgressController {
     return this.progressService.findAll(userId, query);
   }
 
+  @ApiProgress.createOrUpdate()
   @Put('quizzes/:quizId')
-  update(
+  createOrUpdate(
     @Param('id', PositiveIntPipe) userId: number,
     @Param('quizId', PositiveIntPipe) quizId: number,
     @Body() progressData: CreateProgressDto,

--- a/src/progress/progress.controller.ts
+++ b/src/progress/progress.controller.ts
@@ -3,7 +3,9 @@ import { ProgressService } from './progress.service';
 import { CreateProgressDto } from './dto/create-progress.dto';
 import { QueryProgressDto } from './dto/query-progress.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('progress')
 @Controller('users/:id/progress')
 export class ProgressController {
   constructor(private readonly progressService: ProgressService) {}

--- a/src/progress/progress.service.ts
+++ b/src/progress/progress.service.ts
@@ -2,7 +2,6 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateProgressDto } from './dto/create-progress.dto';
 import { QueryProgressDto } from './dto/query-progress.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { Quiz } from '@prisma/client';
 
 @Injectable()
 export class ProgressService {

--- a/src/progress/progress.swagger.ts
+++ b/src/progress/progress.swagger.ts
@@ -1,0 +1,19 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const ApiProgress = {
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '',
+      }),
+    );
+  },
+  createOrUpdate: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '',
+      }),
+    );
+  },
+};

--- a/src/quizzes/dto/create-quiz.dto.ts
+++ b/src/quizzes/dto/create-quiz.dto.ts
@@ -5,23 +5,58 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CreateQuizDto {
   @ApiProperty({
     required: true,
+    description: '자연수 part id 입력',
+    example: 1,
   })
   @IsInt()
   @Min(0)
   readonly partId: number;
 
+  @ApiProperty({
+    required: true,
+    description: '문제 설명란',
+    example: '다음 보기를 보고 문제를 완성하세요',
+  })
   @IsString()
   readonly title: string;
 
+  @ApiProperty({
+    required: true,
+    description: '문제 메인 화면에 보여 줄 실제 문제 내용',
+    example: 'const num : number = 6',
+  })
   @IsString()
   readonly question: string;
 
+  @ApiProperty({
+    required: true,
+    description:
+      '객관식 문제 선택 문항 & 조합형 문제의 선택 단어들 & 그 외 선택사항이 없는 문제들은 빈 배열',
+    example: ['const', 'num', ':number', '6'],
+  })
   @IsString({ each: true })
   readonly answerChoice: string[];
 
+  @ApiProperty({
+    required: true,
+    description:
+      '실제 문제의 정답 & 조합형: 문제정답의 순서가 맞아야함 & 그 외 문제들은 인덱스 0번 배열값과 같아야함',
+    example: ['const', 'num', ':number', '6'],
+  })
   @IsString({ each: true })
   readonly answer: string[];
 
+  @ApiProperty({
+    required: true,
+    description: `
+      문제 유형 , 4가지가 있음 
+      1. COMBINATION : 단어 조합형 문제
+      2. MULTIPLE_CHOICE : 객관식 4문항 문제
+      3. OX_SELECTOR : ox문제
+      4. SHORT_ANSWER : 단답형 문제
+    `,
+    example: 'MULTIPLE_CHOICE',
+  })
   @IsEnum(Category, { message: 'bad category value' })
   readonly category: Category;
 }

--- a/src/quizzes/dto/create-quiz.dto.ts
+++ b/src/quizzes/dto/create-quiz.dto.ts
@@ -1,7 +1,11 @@
 import { IsEnum, IsInt, IsString, Min } from 'class-validator';
 import { Category } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateQuizDto {
+  @ApiProperty({
+    required: true,
+  })
   @IsInt()
   @Min(0)
   readonly partId: number;

--- a/src/quizzes/dto/query-quiz.dto.ts
+++ b/src/quizzes/dto/query-quiz.dto.ts
@@ -1,13 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsNumber, IsOptional, Min } from 'class-validator';
 
 export class QueryQuizDto {
+  @ApiProperty({
+    description: '자연수 section id 입력',
+    example: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(0)
   readonly sectionId?: number;
 
+  @ApiProperty({
+    description: '자연수 part id 입력',
+    example: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/src/quizzes/dto/update-quiz.dto.ts
+++ b/src/quizzes/dto/update-quiz.dto.ts
@@ -1,4 +1,58 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateQuizDto } from './create-quiz.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsString, Min } from 'class-validator';
+import { Category } from '@prisma/client';
 
-export class UpdateQuizDto extends PartialType(CreateQuizDto) {}
+export class UpdateQuizDto extends PartialType(CreateQuizDto) {
+  @ApiProperty({
+    description: '자연수 part id 입력',
+    example: 1,
+  })
+  @IsInt()
+  @Min(0)
+  readonly partId?: number;
+
+  @ApiProperty({
+    description: '문제 설명란',
+    example: '다음 보기를 보고 문제를 완성하세요',
+  })
+  @IsString()
+  readonly title?: string;
+
+  @ApiProperty({
+    description: '문제 메인 화면에 보여 줄 실제 문제 내용',
+    example: 'const num : number = 6',
+  })
+  @IsString()
+  readonly question?: string;
+
+  @ApiProperty({
+    description:
+      '객관식 문제 선택 문항 & 조합형 문제의 선택 단어들 & 그 외 선택사항이 없는 문제들은 빈 배열',
+    example: ['const', 'num', ':number', '6'],
+  })
+  @IsString({ each: true })
+  readonly answerChoice?: string[];
+
+  @ApiProperty({
+    description:
+      '실제 문제의 정답 & 조합형: 문제정답의 순서가 맞아야함 & 그 외 문제들은 인덱스 0번 배열값과 같아야함',
+    example: ['const', 'num', ':number', '6'],
+  })
+  @IsString({ each: true })
+  readonly answer?: string[];
+
+  @ApiProperty({
+    description: `
+      문제 유형 , 4가지가 있음 
+      1. COMBINATION : 단어 조합형 문제
+      2. MULTIPLE_CHOICE : 객관식 4문항 문제
+      3. OX_SELECTOR : ox문제
+      4. SHORT_ANSWER : 단답형 문제
+    `,
+    example: 'MULTIPLE_CHOICE',
+  })
+  @IsEnum(Category, { message: 'bad category value' })
+  readonly category?: Category;
+}

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -14,27 +14,32 @@ import { UpdateQuizDto } from './dto/update-quiz.dto';
 import { QueryQuizDto } from './dto/query-quiz.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiQuizzes } from './quizzes.swagger';
 
 @ApiTags('quizzes')
 @Controller('quizzes')
 export class QuizzesController {
   constructor(private readonly quizzesService: QuizzesService) {}
 
+  @ApiQuizzes.create()
   @Post()
   create(@Body() quizData: CreateQuizDto) {
     return this.quizzesService.create(quizData);
   }
 
+  @ApiQuizzes.findAll()
   @Get()
-  getAll(@Query() query: QueryQuizDto) {
+  findAll(@Query() query: QueryQuizDto) {
     return this.quizzesService.findAll(query);
   }
 
+  @ApiQuizzes.findOne()
   @Get(':id')
-  getOneBySectionPartId(@Param('id', PositiveIntPipe) id: number) {
+  findOne(@Param('id', PositiveIntPipe) id: number) {
     return this.quizzesService.findQuizById(id);
   }
 
+  @ApiQuizzes.update()
   @Put(':id')
   update(
     @Param('id', PositiveIntPipe) id: number,
@@ -43,6 +48,7 @@ export class QuizzesController {
     return this.quizzesService.update(id, quizData);
   }
 
+  @ApiQuizzes.remove()
   @Delete(':id')
   remove(@Param('id', PositiveIntPipe) id: number) {
     return this.quizzesService.remove(id);

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -13,7 +13,9 @@ import { CreateQuizDto } from './dto/create-quiz.dto';
 import { UpdateQuizDto } from './dto/update-quiz.dto';
 import { QueryQuizDto } from './dto/query-quiz.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('quizzes')
 @Controller('quizzes')
 export class QuizzesController {
   constructor(private readonly quizzesService: QuizzesService) {}

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -84,7 +84,11 @@ export class QuizzesService {
   }
 
   async update(id: number, data: UpdateQuizDto) {
+    const { partId } = data;
+
     await this.findQuizById(id);
+
+    await this.findPartById(partId);
 
     return this.prisma.quiz.update({
       where: {

--- a/src/quizzes/quizzes.swagger.ts
+++ b/src/quizzes/quizzes.swagger.ts
@@ -80,6 +80,19 @@ export const ApiQuizzes = {
           },
         },
       }),
+      ApiResponse({
+        status: 400,
+        description: '배열 값을 가지는 속성의 배열안 값이 string이 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['each value in answer must be a string'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
     );
   },
   findAll: () => {

--- a/src/quizzes/quizzes.swagger.ts
+++ b/src/quizzes/quizzes.swagger.ts
@@ -1,0 +1,399 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const ApiQuizzes = {
+  create: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '문제 생성',
+      }),
+      ApiResponse({
+        status: 201,
+        description: '새 문제가 성공적으로 생성됨',
+        content: {
+          JSON: {
+            example: {
+              id: 4,
+              partId: 1,
+              title: '다음 보기를 보고 문제를 완성하세요',
+              question: 'const num : number = 6 ',
+              answer: [':number'],
+              answerChoice: ['const', 'num', ':number', '6'],
+              category: 'SHORT_ANSWER',
+              createdAt: '2024-11-04T05:13:12.363Z',
+              updatedAt: '2024-11-04T05:13:12.363Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: 'partId를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '각 속성들의 타입들이 맞지 않음',
+        content: {
+          JSON: {
+            example: {
+              message: ['title must be a string'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'category속성의 enum값이 잘못됨',
+        content: {
+          JSON: {
+            example: {
+              message: ['bad category value'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '사용하지 않는 속성을 body에 넣은듯 (ex: "test: 2")',
+        content: {
+          JSON: {
+            example: {
+              message: [
+                'property test should not exist',
+                'name must be a string',
+              ],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '문제 전체 조회 & 쿼리를 사용한 부분 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description:
+          '문제 전체속성을 조회함 & 쿼리를 사용해 특정 섹션과 파트 의 문제를 조회',
+        content: {
+          JSON: {
+            example: [
+              {
+                id: 10,
+                partId: 5,
+                title: '문제의 출력 결과는?',
+                question:
+                  'const a = 10;\nlet b = "안녕";\nconsole.log(`${a}는${b}`);',
+                answer: ['10는안녕'],
+                answerChoice: [],
+                category: 'SHORT_ANSWER',
+                createdAt: '2024-11-04T15:45:11.575Z',
+                updatedAt: '2024-11-06T04:29:35.281Z',
+              },
+              {
+                id: 9,
+                partId: 5,
+                title: 'O,X중 하나를 골라주세요',
+                question:
+                  '자바스크립트에서 const로 선언한 변수는 재할당이 불가능하다.',
+                answer: ['O'],
+                answerChoice: [],
+                category: 'OX_SELECTOR',
+                createdAt: '2024-11-01T11:13:34.722Z',
+                updatedAt: '2024-11-01T11:13:34.722Z',
+              },
+              {
+                id: 8,
+                partId: 5,
+                title: '빈칸을 채우시오',
+                question: '#empty# x = 5;',
+                answer: ['let'],
+                answerChoice: [
+                  'let',
+                  'defin',
+                  'function',
+                  'write',
+                  'int',
+                  'new',
+                ],
+                category: 'COMBINATION',
+                createdAt: '2024-11-01T11:12:43.352Z',
+                updatedAt: '2024-11-01T11:12:43.352Z',
+              },
+              {
+                id: 7,
+                partId: 5,
+                title: '다음 중 옳은것은?',
+                question:
+                  '자바스크립트에서 변수를 선언할 때 사용할 수 없는 키워드는 무엇인가요?',
+                answer: ['define'],
+                answerChoice: ['let', 'const', 'var', 'define'],
+                category: 'MULTIPLE_CHOICE',
+                createdAt: '2024-11-01T11:10:42.395Z',
+                updatedAt: '2024-11-01T11:10:42.395Z',
+              },
+              {
+                id: 6,
+                partId: 5,
+                title: '변수에 값을 넣는 방법으로 올바른 키워드를 고르시오',
+                question: 'let a ? 10',
+                answer: ['='],
+                answerChoice: ['=', '!', '@', '^'],
+                category: 'MULTIPLE_CHOICE',
+                createdAt: '2024-11-01T10:52:09.884Z',
+                updatedAt: '2024-11-01T10:54:23.096Z',
+              },
+              {
+                id: 5,
+                partId: 5,
+                title: '맞을까요?',
+                question: 'let 10 + a;',
+                answer: ['X'],
+                answerChoice: [],
+                category: 'OX_SELECTOR',
+                createdAt: '2024-11-01T10:49:26.457Z',
+                updatedAt: '2024-11-01T10:49:26.457Z',
+              },
+            ],
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId가 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['sectionId must not be less than 0'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId가 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['sectionId must be an integer number'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  findOne: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '문제 단일 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '문제 id 통해 특정 한 문제를 조회',
+        content: {
+          JSON: {
+            example: {
+              id: 7,
+              partId: 5,
+              title: '다음 중 옳은것은?',
+              question:
+                '자바스크립트에서 변수를 선언할 때 사용할 수 없는 키워드는 무엇인가요?',
+              answer: ['define'],
+              answerChoice: ['let', 'const', 'var', 'define'],
+              category: 'MULTIPLE_CHOICE',
+              createdAt: '2024-11-01T11:10:42.395Z',
+              updatedAt: '2024-11-01T11:10:42.395Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '문제를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '문제 id가 정수형 숫자값이 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  update: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '단일 문제 수정',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '문제의 id param값을 통해 단일 문제 수정',
+        content: {
+          JSON: {
+            example: {
+              id: 1,
+              partId: 1,
+              title: '예상출력을 작성하세요',
+              question: 'function add(a , b){ return a+b}',
+              answer: ['5'],
+              answerChoice: ['function', 'add(a, b)'],
+              category: 'MULTIPLE_CHOICE',
+              createdAt: '2024-10-31T08:31:11.300Z',
+              updatedAt: '2024-11-06T08:34:23.658Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '문제 id 값 또는 파트 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '문제 body에 속성으로 이상한 속성이 들어옴 ',
+        content: {
+          JSON: {
+            example: {
+              message: [
+                'property sectionId should not exist',
+                'property part should not exist',
+              ],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'part의 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['partId must be an integer number'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  remove: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '단일 문제 삭제',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '문제의 id param값을 통해 단일 문제 삭제',
+        content: {
+          JSON: {
+            example: {
+              id: 1,
+              partId: 1,
+              title: '예상출력을 작성하세요',
+              question: 'function add(a , b){ return a+b}',
+              answer: ['5'],
+              answerChoice: ['function', 'add(a, b)'],
+              category: 'MULTIPLE_CHOICE',
+              createdAt: '2024-10-31T08:31:11.300Z',
+              updatedAt: '2024-11-06T08:38:53.958Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '문제 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '문제 id 값이 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '문제 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+};

--- a/src/sections/dto/create-section.dto.ts
+++ b/src/sections/dto/create-section.dto.ts
@@ -1,6 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 
 export class CreateSectionDto {
+  @ApiProperty({
+    required: true,
+    description: '섹션 이름',
+    example: 'function',
+  })
   @IsString()
   readonly name: string;
 }

--- a/src/sections/sections.controller.ts
+++ b/src/sections/sections.controller.ts
@@ -11,7 +11,9 @@ import { SectionsService } from './sections.service';
 import { CreateSectionDto } from './dto/create-section.dto';
 import { UpdateSectionDto } from './dto/update-section.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('sections')
 @Controller('sections')
 export class SectionsController {
   constructor(private readonly sectionsService: SectionsService) {}

--- a/src/sections/sections.controller.ts
+++ b/src/sections/sections.controller.ts
@@ -12,27 +12,32 @@ import { CreateSectionDto } from './dto/create-section.dto';
 import { UpdateSectionDto } from './dto/update-section.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiSections } from './sections.swagger';
 
 @ApiTags('sections')
 @Controller('sections')
 export class SectionsController {
   constructor(private readonly sectionsService: SectionsService) {}
 
+  @ApiSections.create()
   @Post()
   create(@Body() sectionData: CreateSectionDto) {
     return this.sectionsService.create(sectionData);
   }
 
+  @ApiSections.findAll()
   @Get()
   findAll() {
     return this.sectionsService.findAll();
   }
 
+  @ApiSections.findOne()
   @Get(':id')
   findOne(@Param('id', PositiveIntPipe) id: number) {
     return this.sectionsService.findOne(id);
   }
 
+  @ApiSections.update()
   @Patch(':id')
   update(
     @Param('id', PositiveIntPipe) id: number,
@@ -41,6 +46,7 @@ export class SectionsController {
     return this.sectionsService.update(id, sectionData);
   }
 
+  @ApiSections.remove()
   @Delete(':id')
   remove(@Param('id', PositiveIntPipe) id: number) {
     return this.sectionsService.remove(id);

--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -81,6 +81,16 @@ export class SectionsService {
   async remove(id: number) {
     await this.findSectionById(id);
 
+    const part = await this.prisma.part.findMany({
+      where: {
+        sectionId: id,
+      },
+    });
+
+    if (part.length) {
+      throw new ConflictException('섹션을 참조하고 있는 파트가 있음');
+    }
+
     return this.prisma.section.delete({
       where: {
         id,

--- a/src/sections/sections.swagger.ts
+++ b/src/sections/sections.swagger.ts
@@ -259,6 +259,19 @@ export const ApiSections = {
           },
         },
       }),
+      ApiResponse({
+        status: 409,
+        description: 'section을 참조하고 있는 파트가 있어 삭제를 거부함',
+        content: {
+          JSON: {
+            example: {
+              message: '섹션을 참조하고 있는 파트가 있음',
+              error: 'Conflict',
+              statusCode: 409,
+            },
+          },
+        },
+      }),
     );
   },
 };

--- a/src/sections/sections.swagger.ts
+++ b/src/sections/sections.swagger.ts
@@ -1,0 +1,264 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const ApiSections = {
+  create: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 생성',
+      }),
+      ApiResponse({
+        status: 201,
+        description: 'sections가 성공적으로 생성됨',
+        content: {
+          JSON: {
+            example: {
+              id: 2,
+              name: 'JSON',
+              createdAt: '2024-11-04T10:42:17.052Z',
+              updatedAt: '2024-11-04T10:42:17.052Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'name이 string 이 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['name must be a string'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '사용하지 않는 속성을 body에 넣은듯 (ex: "test: 2")',
+        content: {
+          JSON: {
+            example: {
+              message: [
+                'property test should not exist',
+                'name must be a string',
+              ],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 전체 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: 'section의 전체 id , name 을 조회함',
+        content: {
+          JSON: {
+            example: [
+              {
+                id: 1,
+                name: 'variable',
+                createdAt: '2024-10-31T08:30:54.120Z',
+                updatedAt: '2024-10-31T08:30:54.120Z',
+              },
+              {
+                id: 2,
+                name: 'function',
+                createdAt: '2024-11-04T10:42:17.052Z',
+                updatedAt: '2024-11-04T10:42:17.052Z',
+              },
+              {
+                id: 3,
+                name: 'JSON',
+                createdAt: '2024-11-04T10:52:46.252Z',
+                updatedAt: '2024-11-04T10:52:46.252Z',
+              },
+            ],
+          },
+        },
+      }),
+    );
+  },
+  findOne: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 단일 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '특정 section의 id param값을 통해 id, nmae 값을 조회',
+        content: {
+          JSON: {
+            example: {
+              id: 2,
+              name: 'function',
+              createdAt: '2024-11-04T10:42:17.052Z',
+              updatedAt: '2024-11-04T10:42:17.052Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: 'section의 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  update: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 단일 속성 수정',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '특정 section의 id param값을 통해 nmae 값을 수정',
+        content: {
+          JSON: {
+            example: {
+              id: 3,
+              name: 'typeof',
+              createdAt: '2024-11-04T10:52:46.252Z',
+              updatedAt: '2024-11-04T11:22:33.138Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: 'section의 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+  remove: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'section 단일 삭제',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '특정 section의 id param값을 통해 section 삭제',
+        content: {
+          JSON: {
+            example: {
+              id: 3,
+              name: 'typeof',
+              createdAt: '2024-11-04T10:52:46.252Z',
+              updatedAt: '2024-11-04T11:22:33.138Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: 'section의 id 값을 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'section의 id 값이 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: 'Validation failed (numeric string is expected)',
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+    );
+  },
+};


### PR DESCRIPTION
## 🔗 관련 이슈

#24 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
`sections` `quizzes` `parts` `progress` 4가지 API의 `dto`파일과 `controller` 파일에
스웨거 문서화를 위한 코드가 작성됬습니다.

이제 관련 API의 body 예제나 성공, 실패시 respose 값을 확인해 볼 수 있습니다. (개발 배포 전 로컬환경에서)

@Contingency1 님 @NicoDora 님 @hobiJeong 님 께서 작업하신 fashion24-back 의 스웨거 설정을 참고해 작성됬습니다.
https://github.com/fashion24-developer/fashion24-back


`progress.swagger.ts` 의 `ApiProgress` 클래스 안 메소드의 내용이 굉장히 부실하신걸 확인할 수 있습니다.
progress의 response값은 현재 전체내용을 주는 방향에서 -> `유저가 맞춘 문제를 카운트`해서 주는 방향으로 바뀔예정이기 떄문에
관련 response 값이 크게 바뀔 예정이라 작성을 멈췄습니다.


## 🔍 변경 사항

생성
- [ ] sections.swagger.ts
- [ ] quizzes.swagger.ts
- [ ] parts.swagger.ts
- [ ] progress.swagger.ts

변경
- [ ] controller.ts 파일들
- [ ] dot 디렉토리의 파일들

## 💬리뷰 요구사항 (선택사항)

1. fashion24-back 의 커스텀 데코레이터로 스웨거 데코를 모아쓰는 방식을 참고했습니다. 그런데 제가 커스텀 데코 구현이 미숙해서 관련 작업을 완벽하게 이해하지 못한 상태 입니다. // 스프린트 후 더 작성