### PR TITLE
진행도 response 변경

### DIFF
--- a/src/progress/progress.service.ts
+++ b/src/progress/progress.service.ts
@@ -84,12 +84,11 @@ export class ProgressService {
     option?: { isCorrect: boolean },
   ) {
     const { sectionId, partId } = query;
-    const isCorrect = option?.isCorrect;
 
     return this.prisma.progress.count({
       where: {
         userId,
-        ...(isCorrect && { isCorrect }),
+        ...option,
         quiz: {
           part: {
             ...(partId && { id: partId }),


### PR DESCRIPTION
## 🔗 관련 이슈

#26 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
### 진행도 `progress` API의 `response` 값 변경이 있습니다.

이전 `GET users/progress` 요청은
```JSON
[
    {
        "userId": 1,
        "quizId": 5,
        "isCorrect": true,
        "createdAt": "2024-11-08T05:20:38.468Z",
        "updatedAt": "2024-11-08T05:20:38.468Z"
    },
    {
        "userId": 1,
        "quizId": 6,
        "isCorrect": true,
        "createdAt": "2024-11-08T05:20:44.285Z",
        "updatedAt": "2024-11-08T05:20:44.285Z"
    },
    {
        "userId": 1,
        "quizId": 7,
        "isCorrect": false,
        "createdAt": "2024-11-08T05:20:56.004Z",
        "updatedAt": "2024-11-08T05:20:56.004Z"
    }
]
```

형식의 `response` 를 보내줬습니다. 유저가 푼 문제와 세부 내용을 모두 보내줬습니다.
이 형식을 
```JSON
{
    "totalQuizCount": 2,                       // 전체 문제 수
    "totalUserProgressCount": 1,        // 유저가 푼 문제 수
    "correctUserProgressCount": 0,   // 유저가 맞힌 문제 수
    "inCorrectUserProgressCount": 1 // 유저가 틀린 문제 수
}
```
형식으로 변경합니다.

`전체 문제`와 `유저가 푼 문제`를 구별하는건  유저가 한번도 풀지 않은 문제가 통계에 들어가지 않는걸 막기 위해서 입니다.

### 다중 업데이트 관련 이슈는 잠시 보류됬습니다.


## 🔍 변경 사항

- [x] findAll() 메소드 로직 변경

## 💬리뷰 요구사항 (선택사항)

1. 코드가 좀 길어졌습니다. 저는 prisma 의 count 메소드를 사용해서 값들을 추출했습니다. 그런데 findMany로 값을 불러와서 length를 사용해 카운터를 세는 방법과 비교해 정확히 어떤 이점이 있을지 애매 한것 같습니다. findMany를 사용하면 네트워크 요청 한번을 줄일 수 있어서 고민했는데 일단은 count로 로직을 구성했습니다.
2. 함수명 , 변수명 관련해서 좋은 레퍼런스 있으면 많은 정보 부탁드립니다. 가독성을 위해 간단한 단어들로 조합하다 보니 너무 길어져 오히려 가독성을 해치지 않는지 고민입니다.

---

### copliot 요약
This pull request refactors the `ProgressService` in the `src/progress/progress.service.ts` file to improve code organization and functionality. The main changes include the addition of helper methods to count quizzes and user progress, and the reorganization of the `findAll` method to utilize these new helper methods.

Refactoring and code organization:

* Removed the unused import of `Quiz` from the `@prisma/client`. (`src/progress/progress.service.ts`)
* Refactored the `findAll` method to use new helper methods for counting quizzes and user progress, improving code readability and maintainability. (`src/progress/progress.service.ts`) [[1]](diffhunk://#diff-a39a82c747b8557d7d801426ab97647b7e4aa1185963d2ba9b6eaba6abdfafc1L67-R91) [[2]](diffhunk://#diff-a39a82c747b8557d7d801426ab97647b7e4aa1185963d2ba9b6eaba6abdfafc1R104-R137)

New helper methods:

* Added `countQuizBySectionIdOrPartId` method to count quizzes based on section or part IDs. (`src/progress/progress.service.ts`)
* Added `countUserProgressBySectionIdOrPartId` method to count user progress based on section or part IDs, with an optional filter for correctness. (`src/progress/progress.service.ts`)