### PR TITLE
Modify/#31/sections findone

### DIFF
--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -59,8 +59,6 @@ export class SectionsService {
       throw new NotFoundException();
     }
 
-    console.log(section);
-
     return section;
   }
 

--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -51,14 +51,15 @@ export class SectionsService {
 
   async findOne(id: number) {
     const section = await this.prisma.section.findUnique({
-      where: {
-        id,
-      },
+      where: { id },
+      include: { part: true },
     });
 
     if (!section) {
       throw new NotFoundException();
     }
+
+    console.log(section);
 
     return section;
   }

--- a/src/sections/sections.swagger.ts
+++ b/src/sections/sections.swagger.ts
@@ -94,7 +94,8 @@ export const ApiSections = {
       }),
       ApiResponse({
         status: 200,
-        description: '특정 section의 id param값을 통해 id, nmae 값을 조회',
+        description:
+          '특정 section의 id param값을 통해 id, nmae 값을 조회 또한 id를 참조하는 part객체들을 배열로 보냄',
         content: {
           JSON: {
             example: {
@@ -102,6 +103,22 @@ export const ApiSections = {
               name: 'function',
               createdAt: '2024-11-04T10:42:17.052Z',
               updatedAt: '2024-11-04T10:42:17.052Z',
+              part: [
+                {
+                  id: 1,
+                  sectionId: 1,
+                  name: 'string',
+                  createdAt: '2024-11-18T06:50:00.122Z',
+                  updatedAt: '2024-11-18T06:50:00.122Z',
+                },
+                {
+                  id: 2,
+                  sectionId: 1,
+                  name: 'number',
+                  createdAt: '2024-11-18T06:50:07.072Z',
+                  updatedAt: '2024-11-18T06:50:07.072Z',
+                },
+              ],
             },
           },
         },


### PR DESCRIPTION
## 🔗 관련 이슈

#31 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
<img width="408" alt="스크린샷 2024-11-18 오후 3 53 44" src="https://github.com/user-attachments/assets/8ddab3ed-8208-4719-ba05-baaf422dd23c">

기존 `GET  sections/{id} ` 요청으로는 단일 section을 조회했습니다.
이제는 id를 참조하는 part 들을 배열로 보냅니다.
 
## 🔍 변경 사항

- [ ] include: { part: true }, 옵션 추가

## 💬리뷰 요구사항 (선택사항)
