### PR TITLE
새로운 quizze api , 정답을 틀렸던 문제들을 받기

### DIFF
--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -39,6 +39,12 @@ export class QuizzesController {
     return this.quizzesService.findQuizById(id);
   }
 
+  //스웨거 만들기
+  @Get('users/:id/incorrect')
+  findAllProgressIncorrect(@Param('id', PositiveIntPipe) userId: number) {
+    return this.quizzesService.findAllProgressIncorrect(userId);
+  }
+
   @ApiQuizzes.update()
   @Put(':id')
   update(

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -39,7 +39,7 @@ export class QuizzesController {
     return this.quizzesService.findQuizById(id);
   }
 
-  //스웨거 만들기
+  @ApiQuizzes.findAllProgressIncorrect()
   @Get('users/:id/incorrect')
   findAllProgressIncorrect(@Param('id', PositiveIntPipe) userId: number) {
     return this.quizzesService.findAllProgressIncorrect(userId);

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -41,8 +41,11 @@ export class QuizzesController {
 
   @ApiQuizzes.findAllProgressIncorrect()
   @Get('users/:id/incorrect')
-  findAllProgressIncorrect(@Param('id', PositiveIntPipe) userId: number) {
-    return this.quizzesService.findAllProgressIncorrect(userId);
+  findAllProgressIncorrect(
+    @Param('id', PositiveIntPipe) userId: number,
+    @Query() query: QueryQuizDto,
+  ) {
+    return this.quizzesService.findAllProgressIncorrect(userId, query);
   }
 
   @ApiQuizzes.update()

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -83,6 +83,27 @@ export class QuizzesService {
     return quiz;
   }
 
+  async findAllProgressIncorrect(userId: number) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException();
+    }
+
+    return this.prisma.quiz.findMany({
+      where: {
+        progress: {
+          some: {
+            isCorrect: false,
+            userId,
+          },
+        },
+      },
+    });
+  }
+
   async update(id: number, data: UpdateQuizDto) {
     const { partId } = data;
 

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -89,7 +89,7 @@ export class QuizzesService {
     });
 
     if (!user) {
-      throw new NotFoundException();
+      throw new NotFoundException('존재하지 않는 유저');
     }
 
     return this.prisma.quiz.findMany({

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -83,7 +83,17 @@ export class QuizzesService {
     return quiz;
   }
 
-  async findAllProgressIncorrect(userId: number) {
+  async findAllProgressIncorrect(userId: number, query: QueryQuizDto) {
+    const { sectionId, partId } = query;
+
+    if (sectionId) {
+      await this.findSectionById(sectionId);
+    }
+
+    if (partId) {
+      await this.findPartById(partId);
+    }
+
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
     });
@@ -98,6 +108,12 @@ export class QuizzesService {
           some: {
             isCorrect: false,
             userId,
+          },
+        },
+        part: {
+          ...(partId && { id: partId }),
+          section: {
+            ...(sectionId && { id: sectionId }),
           },
         },
       },

--- a/src/quizzes/quizzes.swagger.ts
+++ b/src/quizzes/quizzes.swagger.ts
@@ -319,6 +319,44 @@ export const ApiQuizzes = {
           },
         },
       }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId가 양수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['sectionId must not be less than 0'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '쿼리 sectionId 또는 partId가 정수가 아님',
+        content: {
+          JSON: {
+            example: {
+              message: ['sectionId must be an integer number'],
+              error: 'Bad Request',
+              statusCode: 400,
+            },
+          },
+        },
+      }),
     );
   },
   update: () => {

--- a/src/quizzes/quizzes.swagger.ts
+++ b/src/quizzes/quizzes.swagger.ts
@@ -279,6 +279,48 @@ export const ApiQuizzes = {
       }),
     );
   },
+  findAllProgressIncorrect: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '유저가 틀렸던 문제 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description:
+          '유저 id 통해 진행도에서 틀렸던 문제를 확인 후 문제를 보냄',
+        content: {
+          JSON: {
+            example: [
+              {
+                id: 1,
+                partId: 1,
+                title: '다음 보기를 보고 문제를 완성하세요2',
+                question: 'const num : number = 6 ',
+                answer: ['6'],
+                answerChoice: ['const', 'num', ':number', '6'],
+                category: 'SHORT_ANSWER',
+                createdAt: '2024-11-18T07:23:23.956Z',
+                updatedAt: '2024-11-18T07:23:23.956Z',
+              },
+            ],
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '존재하지 않는 유저 id',
+        content: {
+          JSON: {
+            example: {
+              message: '존재하지 않는 유저',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+    );
+  },
   update: () => {
     return applyDecorators(
       ApiOperation({


### PR DESCRIPTION
## 🔗 관련 이슈

#33 

## 📝작업 내용
<img width="1390" alt="스크린샷 2024-11-18 오후 4 34 59" src="https://github.com/user-attachments/assets/1cdb1b2f-c775-458d-965b-def01bbe5bf4">

1. `GET /quizzes/users/{id}/incorrect` api 엔드포인트가 하나 생성됬습니다.

이제 이 요청을 통해서 유저가 풀었던 문제들 중 정답을 틀렸던 문제들 배열로 받을 수 있습니다.

2. 관련 api에 대한 스웨거 문서 설정이 되었습니다.

(수정사항)

3. 유저의 모든 문제 중 틀린문제만 받게 설정되었던걸 -> query를 사용해 part와 section별로 받을 수 있도록 수정했습니다.


## 🔍 변경 사항

- [x] `GET /quizzes/users/{id}/incorrect`
- [x] 관련 스웨거문서 작성
- [x] `GET /quizzes/users/{id}/incorrect?partId={id}` 로 수정


## 💬리뷰 요구사항 (선택사항)
