### PR TITLE
part progress API 작성

### DIFF
--- a/prisma/migrations/20241209140233_part_progress_create/migration.sql
+++ b/prisma/migrations/20241209140233_part_progress_create/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "PartStatus" AS ENUM ('LOCKED', 'STARTED', 'IN_PROGRESS', 'COMPLETED');
+
+-- CreateTable
+CREATE TABLE "part_progress" (
+    "user_id" INTEGER NOT NULL,
+    "part_id" INTEGER NOT NULL,
+    "status" "PartStatus" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "part_progress_pkey" PRIMARY KEY ("user_id","part_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "part_progress" ADD CONSTRAINT "part_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "part_progress" ADD CONSTRAINT "part_progress_part_id_fkey" FOREIGN KEY ("part_id") REFERENCES "parts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,13 @@ enum Category {
   SHORT_ANSWER
 }
 
+enum PartStatus {
+  LOCKED
+  STARTED
+  IN_PROGRESS
+  COMPLETED
+}
+
 model Quiz {
   id           Int        @id @default(autoincrement())
   partId       Int        @map("part_id")
@@ -48,22 +55,23 @@ model Section {
 }
 
 model User {
-  id                     Int        @id @default(autoincrement())
-  provider               String     @db.VarChar(20)
-  providerId             String     @unique @map("provider_id")
-  name                   String     @db.VarChar(30)
-  profileImage           String?    @map("profile_image")
-  maxHealthPoint         Int        @default(5) @map("max_health_point")
-  lastLogin              DateTime   @default(now()) @map("last_login")
-  level                  Int        @default(1)
-  experience             Int        @default(0)
-  experienceForNextLevel Int        @default(50) @map("experience_for_next_level")
-  point                  Int        @default(0)
-  createdAt              DateTime   @default(now()) @map("created_at")
-  updatedAt              DateTime   @updatedAt @map("updated_at")
+  id                     Int            @id @default(autoincrement())
+  provider               String         @db.VarChar(20)
+  providerId             String         @unique @map("provider_id")
+  name                   String         @db.VarChar(30)
+  profileImage           String?        @map("profile_image")
+  maxHealthPoint         Int            @default(5) @map("max_health_point")
+  lastLogin              DateTime       @default(now()) @map("last_login")
+  level                  Int            @default(1)
+  experience             Int            @default(0)
+  experienceForNextLevel Int            @default(50) @map("experience_for_next_level")
+  point                  Int            @default(0)
+  createdAt              DateTime       @default(now()) @map("created_at")
+  updatedAt              DateTime       @updatedAt @map("updated_at")
   Progress               Progress[]
   userItems              UserItem[]
   token                  Token[]
+  partProgress           PartProgress[]
 
   @@map("users")
 }
@@ -82,13 +90,14 @@ model Progress {
 }
 
 model Part {
-  id        Int      @id @default(autoincrement())
-  sectionId Int      @map("section_id")
-  name      String   @unique @db.VarChar(255)
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
-  section   Section  @relation(fields: [sectionId], references: [id], onDelete: Restrict)
-  quiz      Quiz[]
+  id           Int            @id @default(autoincrement())
+  sectionId    Int            @map("section_id")
+  name         String         @unique @db.VarChar(255)
+  createdAt    DateTime       @default(now()) @map("created_at")
+  updatedAt    DateTime       @updatedAt @map("updated_at")
+  section      Section        @relation(fields: [sectionId], references: [id], onDelete: Restrict)
+  quiz         Quiz[]
+  PartProgress PartProgress[]
 
   @@map("parts")
 }
@@ -130,4 +139,17 @@ model Token {
   user               User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("token")
+}
+
+model PartProgress {
+  userId    Int        @map("user_id")
+  partId    Int        @map("part_id")
+  status    PartStatus
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @map("updated_at")
+  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  part      Part       @relation(fields: [partId], references: [id], onDelete: Cascade)
+
+  @@id([userId, partId])
+  @@map("part_progress")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { SectionsModule } from './sections/sections.module';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { AppController } from './app.controller';
+import { PartProgressModule } from './part-progress/part-progress.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AppController } from './app.controller';
       isGlobal: true,
     }),
     AuthModule,
+    PartProgressModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/util/type-utils.ts
+++ b/src/common/util/type-utils.ts
@@ -1,0 +1,1 @@
+export type ValueOf<T extends Record<any, any>> = T[keyof T];

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -12,6 +12,7 @@ export class CreatePartProgressDto {
         4. COMPLETED
         `,
     example: 'LOCKED',
+    enum: PartStatus,
   })
   @IsEnum(PartStatus, { message: 'bad status value' })
   readonly status: PartStatus;

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,5 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { PartStatus } from '../entities/part-progress.entity';
 
 export class CreatePartProgressDto {
+  @ApiProperty({
+    description: `
+        part의 status 값 넣기
+        1. LOCKED
+        2. STARTED
+        3. IN_PROGRESS
+        4. COMPLETED
+        `,
+    example: 'LOCKED',
+  })
   readonly status: PartStatus;
 }

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PartStatus } from '../entities/part-progress.entity';
 import { IsEnum } from 'class-validator';
+import { CategoryValues } from 'src/quizzes/entities/quizzes.entity';
 
 export class CreatePartProgressDto {
   @ApiProperty({
@@ -12,8 +13,8 @@ export class CreatePartProgressDto {
         4. COMPLETED
         `,
     example: 'LOCKED',
-    enum: PartStatus,
+    enum: CategoryValues,
   })
-  @IsEnum(PartStatus, { message: 'bad status value' })
+  @IsEnum(CategoryValues, { message: 'bad status value' })
   readonly status: PartStatus;
 }

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePartProgressDto {}

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PartStatus } from '../entities/part-progress.entity';
+import { IsEnum } from 'class-validator';
 
 export class CreatePartProgressDto {
   @ApiProperty({
@@ -12,5 +13,6 @@ export class CreatePartProgressDto {
         `,
     example: 'LOCKED',
   })
+  @IsEnum(PartStatus, { message: 'bad status value' })
   readonly status: PartStatus;
 }

--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,1 +1,5 @@
-export class CreatePartProgressDto {}
+import { PartStatus } from '../entities/part-progress.entity';
+
+export class CreatePartProgressDto {
+  readonly status: PartStatus;
+}

--- a/src/part-progress/dto/res-part-progress.dto.ts
+++ b/src/part-progress/dto/res-part-progress.dto.ts
@@ -1,0 +1,19 @@
+import { PartProgress, PartStatus } from '../entities/part-progress.entity';
+
+export class ResPartProgressDto {
+  readonly userId: number;
+  readonly partId: number;
+  readonly status: PartStatus;
+
+  constructor({ userId, partId, status }: PartProgress) {
+    this.userId = userId;
+    this.partId = partId;
+    this.status = status;
+  }
+
+  static fromArray(partProgress: PartProgress[]): ResPartProgressDto[] {
+    return partProgress.map(
+      (partProgress) => new ResPartProgressDto(partProgress),
+    );
+  }
+}

--- a/src/part-progress/dto/res-part-progress.dto.ts
+++ b/src/part-progress/dto/res-part-progress.dto.ts
@@ -1,8 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { PartProgress, PartStatus } from '../entities/part-progress.entity';
 
 export class ResPartProgressDto {
+  @ApiProperty({ example: 1, description: '유저 아이디' })
   readonly userId: number;
+
+  @ApiProperty({ example: 3, description: '파트 아이디' })
   readonly partId: number;
+
+  @ApiProperty({ example: 'LOCKED', description: '파트 상태' })
   readonly status: PartStatus;
 
   constructor({ userId, partId, status }: PartProgress) {

--- a/src/part-progress/dto/update-part-progress.dto.ts
+++ b/src/part-progress/dto/update-part-progress.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePartProgressDto } from './create-part-progress.dto';
+
+export class UpdatePartProgressDto extends PartialType(CreatePartProgressDto) {}

--- a/src/part-progress/dto/update-part-progress.dto.ts
+++ b/src/part-progress/dto/update-part-progress.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreatePartProgressDto } from './create-part-progress.dto';
-
-export class UpdatePartProgressDto extends PartialType(CreatePartProgressDto) {}

--- a/src/part-progress/entities/part-progress.entity.ts
+++ b/src/part-progress/entities/part-progress.entity.ts
@@ -1,3 +1,5 @@
+import { ValueOf } from 'src/common/util/type-utils';
+
 interface PartProgressModel {
   userId: number;
   partId: number;
@@ -6,14 +8,13 @@ interface PartProgressModel {
   updatedAt: Date;
 }
 
-export const PartStatus = {
+const PartStatusValues = {
   LOCKED: 'LOCKED',
   STARTED: 'STARTED',
   IN_PROGRESS: 'IN_PROGRESS',
   COMPLETED: 'COMPLETED',
 } as const;
-
-export type PartStatus = (typeof PartStatus)[keyof typeof PartStatus];
+export type PartStatus = ValueOf<typeof PartStatusValues>;
 
 export class PartProgress implements PartProgressModel {
   userId: number;

--- a/src/part-progress/entities/part-progress.entity.ts
+++ b/src/part-progress/entities/part-progress.entity.ts
@@ -1,1 +1,24 @@
-export class PartProgress {}
+interface PartProgressModel {
+  userId: number;
+  partId: number;
+  status: PartStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export const PartStatus = {
+  LOCKED: 'LOCKED',
+  STARTED: 'STARTED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+} as const;
+
+export type PartStatus = (typeof PartStatus)[keyof typeof PartStatus];
+
+export class PartProgress implements PartProgressModel {
+  userId: number;
+  partId: number;
+  status: PartStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/part-progress/entities/part-progress.entity.ts
+++ b/src/part-progress/entities/part-progress.entity.ts
@@ -8,7 +8,7 @@ interface PartProgressModel {
   updatedAt: Date;
 }
 
-const PartStatusValues = {
+export const PartStatusValues = {
   LOCKED: 'LOCKED',
   STARTED: 'STARTED',
   IN_PROGRESS: 'IN_PROGRESS',

--- a/src/part-progress/entities/part-progress.entity.ts
+++ b/src/part-progress/entities/part-progress.entity.ts
@@ -1,0 +1,1 @@
+export class PartProgress {}

--- a/src/part-progress/part-progress.controller.spec.ts
+++ b/src/part-progress/part-progress.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PartProgressController } from './part-progress.controller';
+import { PartProgressService } from './part-progress.service';
+
+describe('PartProgressController', () => {
+  let controller: PartProgressController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PartProgressController],
+      providers: [PartProgressService],
+    }).compile();
+
+    controller = module.get<PartProgressController>(PartProgressController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { PartProgressService } from './part-progress.service';
+import { CreatePartProgressDto } from './dto/create-part-progress.dto';
+import { UpdatePartProgressDto } from './dto/update-part-progress.dto';
+
+@Controller('part-progress')
+export class PartProgressController {
+  constructor(private readonly partProgressService: PartProgressService) {}
+
+  @Post()
+  create(@Body() createPartProgressDto: CreatePartProgressDto) {
+    return this.partProgressService.create(createPartProgressDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.partProgressService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.partProgressService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updatePartProgressDto: UpdatePartProgressDto) {
+    return this.partProgressService.update(+id, updatePartProgressDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.partProgressService.remove(+id);
+  }
+}

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -19,9 +19,10 @@ export class PartProgressController {
   @Put('parts/:partId')
   @HttpCode(204)
   async createOrUpdate(
+    @Param('id', PositiveIntPipe) userId: number,
     @Param('partId', PositiveIntPipe) partId: number,
     @Body() body: CreatePartProgressDto,
   ): Promise<void> {
-    await this.partProgressService.createOrUpdate(partId, body);
+    await this.partProgressService.createOrUpdate(userId, partId, body);
   }
 }

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -3,11 +3,13 @@ import { PartProgressService } from './part-progress.service';
 import { CreatePartProgressDto } from './dto/create-part-progress.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ResPartProgressDto } from './dto/res-part-progress.dto';
+import { ApiPartProgress } from './part-progress.swagger';
 
 @Controller('users/:id/part-progress')
 export class PartProgressController {
   constructor(private readonly partProgressService: PartProgressService) {}
 
+  @ApiPartProgress.findAll()
   @Get()
   async findAll(
     @Param('id', PositiveIntPipe) userId: number,
@@ -16,6 +18,7 @@ export class PartProgressController {
     return ResPartProgressDto.fromArray(partProgress);
   }
 
+  @ApiPartProgress.createOrUpdate()
   @Put('parts/:partId')
   @HttpCode(204)
   async createOrUpdate(

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -4,7 +4,9 @@ import { CreatePartProgressDto } from './dto/create-part-progress.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ResPartProgressDto } from './dto/res-part-progress.dto';
 import { ApiPartProgress } from './part-progress.swagger';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('part-progress')
 @Controller('users/:id/part-progress')
 export class PartProgressController {
   constructor(private readonly partProgressService: PartProgressService) {}

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -1,34 +1,27 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Body, Param, Put, HttpCode } from '@nestjs/common';
 import { PartProgressService } from './part-progress.service';
 import { CreatePartProgressDto } from './dto/create-part-progress.dto';
-import { UpdatePartProgressDto } from './dto/update-part-progress.dto';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { ResPartProgressDto } from './dto/res-part-progress.dto';
 
-@Controller('part-progress')
+@Controller('users/:id/part-progress')
 export class PartProgressController {
   constructor(private readonly partProgressService: PartProgressService) {}
 
-  @Post()
-  create(@Body() createPartProgressDto: CreatePartProgressDto) {
-    return this.partProgressService.create(createPartProgressDto);
-  }
-
   @Get()
-  findAll() {
-    return this.partProgressService.findAll();
+  async findAll(
+    @Param('id', PositiveIntPipe) userId: number,
+  ): Promise<ResPartProgressDto[]> {
+    const partProgress = await this.partProgressService.findAll(userId);
+    return ResPartProgressDto.fromArray(partProgress);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.partProgressService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePartProgressDto: UpdatePartProgressDto) {
-    return this.partProgressService.update(+id, updatePartProgressDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.partProgressService.remove(+id);
+  @Put('parts/:partId')
+  @HttpCode(204)
+  async createOrUpdate(
+    @Param('partId', PositiveIntPipe) partId: number,
+    @Body() body: CreatePartProgressDto,
+  ): Promise<void> {
+    await this.partProgressService.createOrUpdate(partId, body);
   }
 }

--- a/src/part-progress/part-progress.module.ts
+++ b/src/part-progress/part-progress.module.ts
@@ -1,0 +1,18 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { PartProgressService } from './part-progress.service';
+import { PartProgressController } from './part-progress.controller';
+import { PartProgressRepository } from './part-progress.repository';
+import { SectionsModule } from 'src/sections/sections.module';
+import { PartsModule } from 'src/parts/parts.module';
+import { QuizzesModule } from 'src/quizzes/quizzes.module';
+
+@Module({
+  imports: [
+    forwardRef(() => SectionsModule),
+    forwardRef(() => PartsModule),
+    forwardRef(() => QuizzesModule),
+  ],
+  controllers: [PartProgressController],
+  providers: [PartProgressService, PartProgressRepository],
+})
+export class PartProgressModule {}

--- a/src/part-progress/part-progress.repository.ts
+++ b/src/part-progress/part-progress.repository.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class PartProgressRepository {
+  constructor(private readonly prisma: PrismaService) {}
+}

--- a/src/part-progress/part-progress.repository.ts
+++ b/src/part-progress/part-progress.repository.ts
@@ -1,7 +1,27 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { CreatePartProgressDto } from './dto/create-part-progress.dto';
+import { PartProgress } from './entities/part-progress.entity';
 
 @Injectable()
 export class PartProgressRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async findAllByUserId(userId: number): Promise<PartProgress[]> {
+    return this.prisma.partProgress.findMany({
+      where: { userId },
+    });
+  }
+
+  async upsertPartProgress(
+    userId: number,
+    partId: number,
+    body: CreatePartProgressDto,
+  ): Promise<PartProgress> {
+    return this.prisma.partProgress.upsert({
+      where: { userId_partId: { userId, partId } },
+      create: { userId, partId, ...body },
+      update: { userId, partId, ...body },
+    });
+  }
 }

--- a/src/part-progress/part-progress.service.spec.ts
+++ b/src/part-progress/part-progress.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PartProgressService } from './part-progress.service';
+
+describe('PartProgressService', () => {
+  let service: PartProgressService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PartProgressService],
+    }).compile();
+
+    service = module.get<PartProgressService>(PartProgressService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/part-progress/part-progress.service.ts
+++ b/src/part-progress/part-progress.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { CreatePartProgressDto } from './dto/create-part-progress.dto';
-import { UpdatePartProgressDto } from './dto/update-part-progress.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { PartProgressRepository } from './part-progress.repository';
 
@@ -22,7 +21,7 @@ export class PartProgressService {
     return `This action returns a #${id} partProgress`;
   }
 
-  update(id: number, updatePartProgressDto: UpdatePartProgressDto) {
+  update(id: number, updatePartProgressDto: CreatePartProgressDto) {
     return `This action updates a #${id} partProgress`;
   }
 

--- a/src/part-progress/part-progress.service.ts
+++ b/src/part-progress/part-progress.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { CreatePartProgressDto } from './dto/create-part-progress.dto';
+import { UpdatePartProgressDto } from './dto/update-part-progress.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { PartProgressRepository } from './part-progress.repository';
+
+@Injectable()
+export class PartProgressService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly partProgressRepository: PartProgressRepository,
+  ) {}
+  create(createPartProgressDto: CreatePartProgressDto) {
+    return 'This action adds a new partProgress';
+  }
+
+  findAll() {
+    return `This action returns all partProgress`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} partProgress`;
+  }
+
+  update(id: number, updatePartProgressDto: UpdatePartProgressDto) {
+    return `This action updates a #${id} partProgress`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} partProgress`;
+  }
+}

--- a/src/part-progress/part-progress.swagger.ts
+++ b/src/part-progress/part-progress.swagger.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ResPartProgressDto } from './dto/res-part-progress.dto';
+import { CreatePartProgressDto } from './dto/create-part-progress.dto';
+
+export const ApiPartProgress = {
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '유저의 전체 문제 풀이 현황 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: `
+        유저와 파트 사이의 진행도를 모두 보여줌
+        `,
+        type: ResPartProgressDto,
+        isArray: true,
+      }),
+    );
+  },
+  createOrUpdate: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '유저의 파트에 대한 진행도생성 또는 업데이트',
+      }),
+      ApiBody({
+        description: `
+        part의 status 값 넣기
+        1. LOCKED
+        2. STARTED
+        3. IN_PROGRESS
+        4. COMPLETED
+        `,
+        type: CreatePartProgressDto,
+      }),
+      ApiResponse({
+        status: 204,
+        description:
+          '유저의 part-progress가 성공적으로 생성되었거나 업데이트 됨',
+      }),
+    );
+  },
+};

--- a/src/progress/progress.swagger.ts
+++ b/src/progress/progress.swagger.ts
@@ -27,7 +27,7 @@ export const ApiProgress = {
         summary: '유저의 문제에 대한 진행도생성 또는 업데이트',
       }),
       ApiBody({
-        description: '섹션 생성에 필요한 정보',
+        description: '유저가 문제를 맞췄는지를 boolean값으로 넣기',
         type: CreateProgressDto,
       }),
       ApiResponse({

--- a/src/quizzes/dto/create-quiz.dto.ts
+++ b/src/quizzes/dto/create-quiz.dto.ts
@@ -50,6 +50,7 @@ export class CreateQuizDto {
       4. SHORT_ANSWER : 단답형 문제
     `,
     example: 'MULTIPLE_CHOICE',
+    enum: Category,
   })
   @IsEnum(Category, { message: 'bad category value' })
   readonly category: Category;

--- a/src/quizzes/dto/create-quiz.dto.ts
+++ b/src/quizzes/dto/create-quiz.dto.ts
@@ -1,6 +1,6 @@
 import { IsEnum, IsInt, IsString, Min } from 'class-validator';
-import { Category } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
+import { Category, CategoryValues } from '../entities/quizzes.entity';
 
 export class CreateQuizDto {
   @ApiProperty({
@@ -50,8 +50,8 @@ export class CreateQuizDto {
       4. SHORT_ANSWER : 단답형 문제
     `,
     example: 'MULTIPLE_CHOICE',
-    enum: Category,
+    enum: CategoryValues,
   })
-  @IsEnum(Category, { message: 'bad category value' })
+  @IsEnum(CategoryValues, { message: 'bad category value' })
   readonly category: Category;
 }

--- a/src/quizzes/entities/quizzes.entity.ts
+++ b/src/quizzes/entities/quizzes.entity.ts
@@ -12,7 +12,7 @@ interface QuizModel {
   updatedAt: Date;
 }
 
-const CategoryValues = {
+export const CategoryValues = {
   COMBINATION: 'COMBINATION',
   MULTIPLE_CHOICE: 'MULTIPLE_CHOICE',
   OX_SELECTOR: 'OX_SELECTOR',

--- a/src/quizzes/entities/quizzes.entity.ts
+++ b/src/quizzes/entities/quizzes.entity.ts
@@ -1,3 +1,5 @@
+import { ValueOf } from 'src/common/util/type-utils';
+
 interface QuizModel {
   id: number;
   partId: number;
@@ -10,14 +12,13 @@ interface QuizModel {
   updatedAt: Date;
 }
 
-export const Category = {
+const CategoryValues = {
   COMBINATION: 'COMBINATION',
   MULTIPLE_CHOICE: 'MULTIPLE_CHOICE',
   OX_SELECTOR: 'OX_SELECTOR',
   SHORT_ANSWER: 'SHORT_ANSWER',
 } as const;
-
-export type Category = (typeof Category)[keyof typeof Category];
+export type Category = ValueOf<typeof CategoryValues>;
 
 export class Quiz implements QuizModel {
   id: number;


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->
#44 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
part 와 user 사이에 새로운 상태가 필요했습니다.
유저의 파트 진행도를 볼 수 있는 part-progress API를 작성했습니다.

1. `GET /users/:id/parts-progress` 요청입니다.
```ts
[
  {
    "userId": 1,
    "partId": 3,
    "status": "LOCKED"
  }
]
```
위처럼 특정유저의  파트 진행 상태를 모두 보여줍니다. 

2. `PUT /users/:id/parts-progress/parts/:partId`
```ts
{
  "status": "LOCKED"
}
```
생성 및 수정에 관한 요청입니다.
status 값을 넣어줘야 합니다.

3. PartStatus 값들
```ts
enum PartStatus {
  LOCKED
  STARTED
  IN_PROGRESS
  COMPLETED
}
```
위처럼 enum 값 4개를 정했습니다.


4. prisma schema 가 수정되며 마이그레이션 파일이 추가 됩니다.
백엔드 분들은 필히 prisma 마이그레트  해주세요.

## 🔍 변경 사항

- [x] `GET /users/:id/parts-progress`
- [x] `PUT /users/:id/parts-progress/parts/:partId`

## 💬리뷰 요구사항 (선택사항)
-
