### PR TITLE
section/{id}/users/{id}/part-status  API 작성

### DIFF
--- a/src/part-progress/dto/create-part-progress.dto.ts
+++ b/src/part-progress/dto/create-part-progress.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { PartStatus } from '../entities/part-progress.entity';
+import { PartStatus, PartStatusValues } from '../entities/part-progress.entity';
 import { IsEnum } from 'class-validator';
-import { CategoryValues } from 'src/quizzes/entities/quizzes.entity';
 
 export class CreatePartProgressDto {
   @ApiProperty({
@@ -13,8 +12,8 @@ export class CreatePartProgressDto {
         4. COMPLETED
         `,
     example: 'LOCKED',
-    enum: CategoryValues,
+    enum: PartStatusValues,
   })
-  @IsEnum(CategoryValues, { message: 'bad status value' })
+  @IsEnum(PartStatusValues, { message: 'bad status value' })
   readonly status: PartStatus;
 }

--- a/src/sections/dto/res-section.dto.ts
+++ b/src/sections/dto/res-section.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ResPartDto } from 'src/parts/dto/res-part.part.dto';
-import { Part } from 'src/parts/entities/part.entity';
 
 export class ResSectionDto {
   @ApiProperty({ example: 1 })

--- a/src/sections/dto/res-section.dto.ts
+++ b/src/sections/dto/res-section.dto.ts
@@ -10,7 +10,7 @@ export class ResSectionDto {
   readonly name: string;
 
   @ApiProperty({ type: [ResPartDto], example: [] })
-  readonly part?: Part[];
+  readonly part?: ResPartDto[];
 
   constructor({ id, name, part }: ResSectionDto) {
     this.id = id;

--- a/src/sections/sections.controller.ts
+++ b/src/sections/sections.controller.ts
@@ -36,6 +36,17 @@ export class SectionsController {
     return new ResSectionDto(sectionWithParts);
   }
 
+  //@ApiSections.findOne()
+  @Get(':id/users/:userId/part-status')
+  async findOneWithStatus(
+    @Param('userId', PositiveIntPipe) userId: number,
+    @Param('id', PositiveIntPipe) id: number,
+  ) {
+    const sectionWithParts =
+      await this.sectionsService.findOneWithPartsAndStatus(userId, id);
+    return new ResSectionDto(sectionWithParts);
+  }
+
   @ApiSections.create()
   @Post()
   @HttpCode(204)

--- a/src/sections/sections.controller.ts
+++ b/src/sections/sections.controller.ts
@@ -36,7 +36,7 @@ export class SectionsController {
     return new ResSectionDto(sectionWithParts);
   }
 
-  //@ApiSections.findOne()
+  @ApiSections.findOneWithStatus()
   @Get(':id/users/:userId/part-status')
   async findOneWithStatus(
     @Param('userId', PositiveIntPipe) userId: number,

--- a/src/sections/sections.repository.ts
+++ b/src/sections/sections.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateSectionDto } from './dto/create-section.dto';
 import { Section } from './entities/section.entity';
+import { ResSectionDto } from './dto/res-section.dto';
 
 @Injectable()
 export class SectionsRepository {
@@ -17,10 +18,26 @@ export class SectionsRepository {
     });
   }
 
-  async findSectionWithPartsById(id: number): Promise<Section> {
+  async findSectionWithPartsById(id: number): Promise<ResSectionDto> {
     return this.prisma.section.findUnique({
       where: { id },
       include: { part: true },
+    });
+  }
+
+  async findSectionWithPartStatus(userId: number, id: number) {
+    return this.prisma.section.findUnique({
+      where: { id },
+      include: {
+        part: {
+          include: {
+            PartProgress: {
+              where: { userId },
+              select: { status: true },
+            },
+          },
+        },
+      },
     });
   }
 

--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -7,6 +7,7 @@ import { CreateSectionDto } from './dto/create-section.dto';
 import { SectionsRepository } from './sections.repository';
 import { PartsRepository } from 'src/parts/parts.repository';
 import { Section } from './entities/section.entity';
+import { ResSectionDto } from './dto/res-section.dto';
 
 @Injectable()
 export class SectionsService {
@@ -29,7 +30,7 @@ export class SectionsService {
     return section;
   }
 
-  async findOneWithParts(id: number): Promise<Section> {
+  async findOneWithParts(id: number): Promise<ResSectionDto> {
     const sectionWithParts =
       await this.sectionsRepository.findSectionWithPartsById(id);
 
@@ -38,6 +39,31 @@ export class SectionsService {
     }
 
     return sectionWithParts;
+  }
+
+  async findOneWithPartsAndStatus(
+    userId: number,
+    id: number,
+  ): Promise<ResSectionDto> {
+    const { part, ...section } =
+      await this.sectionsRepository.findSectionWithPartStatus(userId, id);
+
+    if (!section) {
+      throw new NotFoundException();
+    }
+
+    // ropository에서 받은 값 중 part를 정리하는 코드
+    const newParts = part.map(
+      ({ PartProgress, createdAt, updatedAt, ...orders }) => ({
+        ...orders,
+        status: PartProgress[0]?.status,
+      }),
+    );
+
+    return {
+      ...section,
+      part: newParts,
+    };
   }
 
   async create(body: CreateSectionDto): Promise<Section> {

--- a/src/sections/sections.swagger.ts
+++ b/src/sections/sections.swagger.ts
@@ -161,6 +161,52 @@ export const ApiSections = {
       }),
     );
   },
+  findOneWithStatus: () => {
+    return applyDecorators(
+      ApiOperation({
+        description: `
+          section id와 유저 id로 조회
+          1. 단일 section 정보 
+          2. 관련 part들의 정보 
+          3. part내부에 진행도와 관련된 status항목을 추가함
+          4. status값이 없으면 유저가 그 파트에 대한 진행도 사항이 undefind인 오류 상황임`,
+      }),
+      ApiResponse({
+        status: 200,
+        description:
+          '특정 section의 id param값을 통해 id, nmae 값을 조회 또한 id를 참조하는 part객체들을 배열로 보냄',
+        type: ResSectionDto,
+        content: {
+          JSON: {
+            example: {
+              id: 1,
+              name: '변수',
+              part: [
+                {
+                  id: 1,
+                  sectionId: 1,
+                  name: '변수명',
+                  status: 'LOCKED',
+                },
+                {
+                  id: 2,
+                  sectionId: 1,
+                  name: 'const',
+                  status: 'LOCKED',
+                },
+                {
+                  id: 3,
+                  sectionId: 1,
+                  name: 'let',
+                  status: 'LOCKED',
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+  },
   update: () => {
     return applyDecorators(
       ApiOperation({

--- a/src/sections/sections.swagger.ts
+++ b/src/sections/sections.swagger.ts
@@ -175,7 +175,6 @@ export const ApiSections = {
         status: 200,
         description:
           '특정 section의 id param값을 통해 id, nmae 값을 조회 또한 id를 참조하는 part객체들을 배열로 보냄',
-        type: ResSectionDto,
         content: {
           JSON: {
             example: {


### PR DESCRIPTION
## 🔗 관련 이슈

#49 

## 📝작업 내용

1. section 모듈에 새로운 api
`GET /section/{id}/users/{id}/part-status`를 작성했습니다.

기존의 `sections/{id}` 요청이 단일 section정보와 관련된 part정보를 가져왔는데
추가로 part에 partProgress의 status를 추가하는 api 입니다.

```ts
// res 예시
{
    "id": 1,
    "name": "변수",
    "part": [
        {
            "id": 1,
            "sectionId": 1,
            "name": "변수명",
            "status": "LOCKED"
        },
        {
            "id": 2,
            "sectionId": 1,
            "name": "const",
            "status": "LOCKED"
        },
        {
            "id": 3,
            "sectionId": 1,
            "name": "let"
        }
    ]
}
```

이제 다음 작업으로 생각해봐야하는건, 위 예시중
```ts
 {
            "id": 3,
            "sectionId": 1,
            "name": "let"
 }
```
처럼 status 가 안나오는 경우를 없애는 것입니다.
해당 상황은 user 1번이 part 3번에 대한 진행도 정보 레코드가 아예 없는 상황입니다. 그래서
**1. 유저가 생성될때, 기본적으로 모든 part에 대한 partProgress 를 생성해야합니다.**

그 다음 
**2. 새로운 part가 생성될때 모든 user에 대해서 새로 추가된 part에 대한 진행도(partProgress)를 만들어야합니다.**

이 두가지 작업이 다음 pr에서 만들어질 예정입니다.


## 🔍 변경 사항

- [x] `GET /section/{id}/users/{id}/part-status` 작성 + 스웨거

## 💬리뷰 요구사항 (선택사항)
