### PR TITLE
파트의 순서(order) 값이 중첩되지 않았던 오류 수정

### DIFF
--- a/src/parts/parts.repository.ts
+++ b/src/parts/parts.repository.ts
@@ -13,6 +13,13 @@ export class PartsRepository {
     });
   }
 
+  async findAllPartBySectionId(sectionId: number): Promise<Part[]> {
+    return this.prisma.part.findMany({
+      where: { sectionId },
+      orderBy: { order: 'asc' },
+    });
+  }
+
   async findOnePartById(id: number): Promise<Part> {
     return this.prisma.part.findUnique({
       where: { id },

--- a/src/parts/parts.repository.ts
+++ b/src/parts/parts.repository.ts
@@ -31,8 +31,9 @@ export class PartsRepository {
     });
   }
 
-  async findPartMaxOrder(): Promise<number> {
+  async findPartMaxOrderBySectionId(sectionId: number): Promise<number> {
     const result = await this.prisma.part.aggregate({
+      where: { sectionId },
       _max: { order: true },
     });
     return result._max.order ?? 0;

--- a/src/parts/parts.service.ts
+++ b/src/parts/parts.service.ts
@@ -90,7 +90,8 @@ export class PartsService {
       throw new ConflictException('part의 이름은 유니크 해야합니다.');
     }
 
-    const maxOrder = await this.partsRepository.findPartMaxOrder();
+    const maxOrder =
+      await this.partsRepository.findPartMaxOrderBySectionId(sectionId);
     const newOrder = maxOrder + 1;
 
     return this.partsRepository.createPartById({ ...body, order: newOrder });

--- a/src/parts/parts.service.ts
+++ b/src/parts/parts.service.ts
@@ -27,10 +27,12 @@ export class PartsService {
    * @returns 재배열된 파트 ID 배열
    */
   private async reorderPartIds(
-    movingId: number,
+    { id, sectionId }: Part,
     newOrder: number,
   ): Promise<number[]> {
-    const parts = await this.partsRepository.findAllPart();
+    const movingId = id;
+
+    const parts = await this.partsRepository.findAllPartBySectionId(sectionId);
     const partIds = parts.map((part) => part.id);
     const currentIndex = partIds.indexOf(movingId);
 
@@ -111,7 +113,7 @@ export class PartsService {
     }
 
     // 섹션 순서 재배치를 위한 처리
-    const updatedSectionIds = await this.reorderPartIds(id, body.order);
+    const updatedSectionIds = await this.reorderPartIds(part, body.order);
 
     // 데이터베이스의 섹션 순서를 업데이트
     await this.updatePartOrders(updatedSectionIds);


### PR DESCRIPTION
## 🔗 관련 이슈

#58 

## 📝작업 내용

<img width="274" alt="image" src="https://github.com/user-attachments/assets/1a90de44-2a40-40be-8782-d9904bd09b24" />

위 이미지처럼 설계 되었어야할 order 가 아래 이미지처럼 생성되고 업데이트 되던 에러를 수정했습니다.

<img width="307" alt="image" src="https://github.com/user-attachments/assets/407040d6-0d98-44fe-aaeb-8895837afb8c" />


## 🔍 변경 사항

- [ ] partsService, partsRepository 수정
- [ ] partsService의 part update 관련 메소드들 수정 

## 💬리뷰 요구사항 (선택사항)
