### PR TITLE
유저 생명력 api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.USER_NAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN_dg1418 }}
 
       # Build 및 push
       - name: Build and push
@@ -60,8 +60,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.USER_NAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN_dg1418 }}
 
       # 앱 이미지 이름 업데이트
       - name: Update DOCKER_IMAGE in .env file

--- a/prisma/migrations/20250103050017_create_user_hp_and_change_user_schema/migration.sql
+++ b/prisma/migrations/20250103050017_create_user_hp_and_change_user_schema/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `last_login` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `max_health_point` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `profile_image` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "last_login",
+DROP COLUMN "max_health_point",
+DROP COLUMN "profile_image";
+
+-- CreateTable
+CREATE TABLE "UserHp" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "hp" INTEGER NOT NULL DEFAULT 5,
+    "hp_storage" INTEGER NOT NULL DEFAULT 5,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserHp_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserHp_user_id_key" ON "UserHp"("user_id");

--- a/prisma/migrations/20250103051335_relation_user_hp/migration.sql
+++ b/prisma/migrations/20250103051335_relation_user_hp/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "UserHp" ADD CONSTRAINT "UserHp_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250103052032_change_user_hp_table_name/migration.sql
+++ b/prisma/migrations/20250103052032_change_user_hp_table_name/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserHp` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UserHp" DROP CONSTRAINT "UserHp_user_id_fkey";
+
+-- DropTable
+DROP TABLE "UserHp";
+
+-- CreateTable
+CREATE TABLE "user_hps" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "hp" INTEGER NOT NULL DEFAULT 5,
+    "hp_storage" INTEGER NOT NULL DEFAULT 5,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_hps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_hps_user_id_key" ON "user_hps"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_hps" ADD CONSTRAINT "user_hps_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,4 +163,6 @@ model UserHp {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("user_hps")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,9 +60,6 @@ model User {
   provider               String         @db.VarChar(20)
   providerId             String         @unique @map("provider_id")
   name                   String         @db.VarChar(30)
-  profileImage           String?        @map("profile_image")
-  maxHealthPoint         Int            @default(5) @map("max_health_point")
-  lastLogin              DateTime       @default(now()) @map("last_login")
   level                  Int            @default(1)
   experience             Int            @default(0)
   experienceForNextLevel Int            @default(50) @map("experience_for_next_level")
@@ -154,4 +151,13 @@ model PartProgress {
 
   @@id([userId, partId])
   @@map("part_progress")
+}
+
+model UserHp {
+  id        Int      @id @default(autoincrement())
+  userId    Int      @unique @map("user_id")
+  hp        Int      @default(5)
+  hpStorage Int      @default(5) @map("hp_storage")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model User {
   userItems              UserItem[]
   token                  Token[]
   partProgress           PartProgress[]
+  userHp                 UserHp?
 
   @@map("users")
 }
@@ -160,4 +161,6 @@ model UserHp {
   hpStorage Int      @default(5) @map("hp_storage")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,26 +1,22 @@
 import { Module } from '@nestjs/common';
 import { AppService } from './app.service';
-import { UserPointModule } from './users/modules/user-point.module';
-import { UserExperienceModule } from './users/modules/user-experience.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ItemsModule } from './items/items.module';
-import { UsersModule } from './users/modules/users.module';
 import { SectionsModule } from './sections/sections.module';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { AppController } from './app.controller';
+import { UsersCoreModule } from './users/modules/users-core.module';
 
 @Module({
   imports: [
-    SectionsModule,
-    PrismaModule,
-    UsersModule,
-    UserPointModule,
-    UserExperienceModule,
-    ItemsModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    PrismaModule,
+    SectionsModule,
+    UsersCoreModule,
+    ItemsModule,
     AuthModule,
   ],
   controllers: [AppController],

--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -94,6 +94,8 @@ export class SectionsService {
     userId: number,
     id: number,
   ): Promise<ResSectionDto> {
+    await this.findOne(id);
+
     const { part, ...section } =
       await this.sectionsRepository.findSectionWithPartStatus(userId, id);
 

--- a/src/users/constants/user-experience.constant.ts
+++ b/src/users/constants/user-experience.constant.ts
@@ -2,10 +2,17 @@
  * 레벨업 시 증가하는 값
  * @type {nubmer}
  */
-export const LEVEL_UP = 1;
+export const LEVEL_UP: number = 1;
 
 /**
  * 레벨업 시 다음 레벨까지 필요한 경험치의 증가 배율
  * @type {number}
  */
-export const INCREASE_MULTIPLIER = 1.2;
+export const INCREASE_MULTIPLIER: number = 1.2;
+
+/**
+ * 유저 생명력을 다시 가득 채울 시간
+ * 25.01.04 기준 20분 : 1200000 밀리초
+ * @type {number}
+ */
+export const HP_FULL_RECHARGE_TIME: number = 1200000;

--- a/src/users/controllers/user-hp.controller.spec.ts
+++ b/src/users/controllers/user-hp.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserHpController } from './user-hp.controller';
+
+describe('UserHpController', () => {
+  let controller: UserHpController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserHpController],
+    }).compile();
+
+    controller = module.get<UserHpController>(UserHpController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -5,12 +5,14 @@ import { UpdateHpDto } from '../dtos/update-hp.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/get-user.decorator';
 import { ResUserHpDto } from '../dtos/res-user-hp.dto';
+import { ApiUserHp } from '../swaggers/user-hp.swagger';
 
 @ApiTags('user-hp')
 @Controller('users/user-hp')
 export class UserHpController {
   constructor(private readonly userHpService: UserHpService) {}
 
+  @ApiUserHp.getUserHp()
   @Get()
   @UseGuards(AuthGuard('accessToken'))
   async getUserHp(@User() user: any): Promise<ResUserHpDto> {
@@ -18,6 +20,7 @@ export class UserHpController {
     return new ResUserHpDto(userHp);
   }
 
+  @ApiUserHp.updateUserHp()
   @Patch()
   @UseGuards(AuthGuard('accessToken'))
   async updateUserHp(

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { UserHpService } from '../services/user-hp.service';
+import { UpdateHpDto } from '../dtos/update-hp.dto';
 
 @ApiTags('hp')
 @Controller('users/:userId/user-hp')
@@ -16,7 +17,7 @@ export class UserHpController {
   @Patch()
   async updateUserHp(
     @Param('userId', PositiveIntPipe) userId: number,
-    @Body() body: any,
+    @Body() body: UpdateHpDto,
   ) {
     return this.userHpService.updateUserHpByUserId(userId, body);
   }

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -1,24 +1,24 @@
-import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { UserHpService } from '../services/user-hp.service';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { User } from 'src/common/decorators/get-user.decorator';
 
-@ApiTags('hp')
-@Controller('users/:userId/user-hp')
+@ApiTags('user-hp')
+@Controller('userss/user-hp')
 export class UserHpController {
   constructor(private readonly userHpService: UserHpService) {}
 
   @Get()
-  async getUserHp(@Param('userId', PositiveIntPipe) userId: number) {
-    return this.userHpService.findUserHpByUserId(userId);
+  @UseGuards(AuthGuard('accessToken'))
+  async getUserHp(@User() user: any) {
+    return this.userHpService.findUserHpByUserId(user.id);
   }
 
   @Patch()
-  async updateUserHp(
-    @Param('userId', PositiveIntPipe) userId: number,
-    @Body() body: UpdateHpDto,
-  ) {
-    return this.userHpService.updateUserHpByUserId(userId, body);
+  @UseGuards(AuthGuard('accessToken'))
+  async updateUserHp(@User() user: any, @Body() body: UpdateHpDto) {
+    return this.userHpService.updateUserHpByUserId(user.id, body);
   }
 }

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -4,7 +4,15 @@ import { UserHpService } from '../services/user-hp.service';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/get-user.decorator';
+import { ResUserHpDto } from '../dtos/res-user-hp.dto';
 
+/**
+ * @todo
+ * users/user-hp 가 아닌
+ * userss/user-hp 라고 작성되있음
+ * 이유는 users/:id 요청이 이 요청들을 가져가기 떄문에 임시로 바꿈
+ * 추후에 어떻게 할지 회의가 필요함
+ */
 @ApiTags('user-hp')
 @Controller('userss/user-hp')
 export class UserHpController {
@@ -12,13 +20,18 @@ export class UserHpController {
 
   @Get()
   @UseGuards(AuthGuard('accessToken'))
-  async getUserHp(@User() user: any) {
-    return this.userHpService.findUserHpByUserId(user.id);
+  async getUserHp(@User() user: any): Promise<ResUserHpDto> {
+    const userHp = await this.userHpService.findUserHpByUserId(user.id);
+    return new ResUserHpDto(userHp);
   }
 
   @Patch()
   @UseGuards(AuthGuard('accessToken'))
-  async updateUserHp(@User() user: any, @Body() body: UpdateHpDto) {
-    return this.userHpService.updateUserHpByUserId(user.id, body);
+  async updateUserHp(
+    @User() user: any,
+    @Body() body: UpdateHpDto,
+  ): Promise<ResUserHpDto> {
+    const userHp = await this.userHpService.updateUserHpByUserId(user.id, body);
+    return new ResUserHpDto(userHp);
   }
 }

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -4,18 +4,18 @@ import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe
 import { UserHpService } from '../services/user-hp.service';
 
 @ApiTags('hp')
-@Controller('users/:id/user-hp')
+@Controller('users/:userId/user-hp')
 export class UserHpController {
   constructor(private readonly userHpService: UserHpService) {}
 
   @Get()
-  getUserHp(@Param('id', PositiveIntPipe) userId: number) {
+  async getUserHp(@Param('userId', PositiveIntPipe) userId: number) {
     return this.userHpService.findUserHpByUserId(userId);
   }
 
   @Patch()
-  updateUserHp(
-    @Param('id', PositiveIntPipe) userId: number,
+  async updateUserHp(
+    @Param('userId', PositiveIntPipe) userId: number,
     @Body() body: any,
   ) {
     return this.userHpService.updateUserHpByUserId(userId, body);

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { UserHpService } from '../services/user-hp.service';
+
+@ApiTags('hp')
+@Controller('users/:id/user-hp')
+export class UserHpController {
+  constructor(private readonly userHpService: UserHpService) {}
+
+  @Get()
+  getUserHp(@Param('id', PositiveIntPipe) userId: number) {
+    return this.userHpService.findUserHpByUserId(userId);
+  }
+
+  @Patch()
+  updateUserHp(
+    @Param('id', PositiveIntPipe) userId: number,
+    @Body() body: any,
+  ) {
+    return this.userHpService.updateUserHpByUserId(userId, body);
+  }
+}

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -6,15 +6,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/get-user.decorator';
 import { ResUserHpDto } from '../dtos/res-user-hp.dto';
 
-/**
- * @todo
- * users/user-hp 가 아닌
- * userss/user-hp 라고 작성되있음
- * 이유는 users/:id 요청이 이 요청들을 가져가기 떄문에 임시로 바꿈
- * 추후에 어떻게 할지 회의가 필요함
- */
 @ApiTags('user-hp')
-@Controller('userss/user-hp')
+@Controller('users/user-hp')
 export class UserHpController {
   constructor(private readonly userHpService: UserHpService) {}
 

--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -12,16 +12,6 @@ export class CreateUserDto {
 
   @ApiProperty({
     type: String,
-    description: '유저 프로필 이미지지',
-    example:
-      'https://lh3.googleusercontent.com/a/ACg8ocK6wP1234RJfzG7BqWeqwerMuxJuIbBhmoYA7gus-EsM=s96-c',
-  })
-  @IsOptional()
-  @IsString()
-  readonly picture?: string;
-
-  @ApiProperty({
-    type: String,
     description: '유저 닉네임',
     example: 'gwgw99',
     minimum: 2,

--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -37,7 +37,7 @@ export class CreateUserDto {
       'ya29.a0AeDClZDZpzSfkfMpmn2qwerJsfaM5JZ0IbvupkAnLDHnwEFL3KtN8Iw7uMrzBdhCkSMDv0DNq9WSmWBBKbE0jzq-9r5g8TJYBhnlELNzzNl7R0A7uADJ5ECZ6WIrUZ3QHWxW7_qqA-OBh6OvHqwerU1gIskGHHvSSpBmaCgYKAaASARESFQ',
   })
   @IsString()
-  socialAccessToken: string;
+  readonly socialAccessToken: string;
 
   @ApiProperty({
     type: String,
@@ -47,7 +47,7 @@ export class CreateUserDto {
   })
   @IsString()
   @IsOptional()
-  socialRefeshToken?: string;
+  readonly socialRefeshToken?: string;
 
   @ApiProperty({
     type: String,

--- a/src/users/dtos/res-user-hp.dto.ts
+++ b/src/users/dtos/res-user-hp.dto.ts
@@ -1,0 +1,19 @@
+import { UserHp } from '../entities/user-hp.entity';
+
+export class ResUserHpDto {
+  readonly id: number;
+  readonly userId: number;
+  readonly hp: number;
+  readonly hpStorage: number;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+
+  constructor(userHp: UserHp) {
+    this.id = userHp.id;
+    this.userId = userHp.userId;
+    this.hp = userHp.hp;
+    this.hpStorage = userHp.hpStorage;
+    this.createdAt = userHp.createdAt;
+    this.updatedAt = userHp.createdAt;
+  }
+}

--- a/src/users/dtos/res-user-hp.dto.ts
+++ b/src/users/dtos/res-user-hp.dto.ts
@@ -1,17 +1,13 @@
 import { UserHp } from '../entities/user-hp.entity';
 
 export class ResUserHpDto {
-  readonly id: number;
   readonly userId: number;
   readonly hp: number;
   readonly hpStorage: number;
-  readonly updatedAt: Date;
 
   constructor(userHp: UserHp) {
-    this.id = userHp.id;
     this.userId = userHp.userId;
     this.hp = userHp.hp;
     this.hpStorage = userHp.hpStorage;
-    this.updatedAt = userHp.updatedAt;
   }
 }

--- a/src/users/dtos/res-user-hp.dto.ts
+++ b/src/users/dtos/res-user-hp.dto.ts
@@ -5,7 +5,6 @@ export class ResUserHpDto {
   readonly userId: number;
   readonly hp: number;
   readonly hpStorage: number;
-  readonly createdAt: Date;
   readonly updatedAt: Date;
 
   constructor(userHp: UserHp) {
@@ -13,7 +12,6 @@ export class ResUserHpDto {
     this.userId = userHp.userId;
     this.hp = userHp.hp;
     this.hpStorage = userHp.hpStorage;
-    this.createdAt = userHp.createdAt;
-    this.updatedAt = userHp.createdAt;
+    this.updatedAt = userHp.updatedAt;
   }
 }

--- a/src/users/dtos/response-user.dto.ts
+++ b/src/users/dtos/response-user.dto.ts
@@ -5,13 +5,10 @@ export class ResponseUserDto {
   readonly provider: string;
   readonly providerId: string;
   readonly name: string;
-  readonly profileImage: string;
-  readonly maxHealthPoint: number;
   readonly level: number;
   readonly experience: number;
   readonly experienceForNextLevel: number;
   readonly point: number;
-  readonly lastLogin: Date;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 
@@ -20,13 +17,10 @@ export class ResponseUserDto {
     this.provider = user.provider;
     this.providerId = user.providerId;
     this.name = user.name;
-    this.profileImage = user.profileImage;
-    this.maxHealthPoint = user.maxHealthPoint;
     this.level = user.level;
     this.experience = user.experience;
     this.experienceForNextLevel = user.experienceForNextLevel;
     this.point = user.point;
-    this.lastLogin = user.lastLogin;
     this.createdAt = user.createdAt;
     this.updatedAt = user.createdAt;
   }

--- a/src/users/dtos/update-hp.dto.ts
+++ b/src/users/dtos/update-hp.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class UpdateHpDto {
+  @ApiProperty({
+    description: `
+      유저의 현재 생명력 수치,
+      1. 문제를 틀리면 -1씩 줄어들 수치,
+      2. 유저는 최소 0, 최대 hpStorage값 까지만 hp값을 가질 수 있음
+    `,
+    example: 4,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  readonly hp?: number;
+
+  @ApiProperty({
+    required: true,
+    description:
+      '유저의 최대 생명력 수치, 디폴트 5이기 때문에 최소 5값을 가져야함',
+    example: 5,
+    minimum: 5,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(5)
+  readonly hpStorage?: number;
+}

--- a/src/users/entities/user-hp.entity.ts
+++ b/src/users/entities/user-hp.entity.ts
@@ -1,0 +1,17 @@
+interface UserHpModel {
+  id: number;
+  userId: number;
+  hp: number;
+  hpStorage: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class UserHp implements UserHpModel {
+  id: number;
+  userId: number;
+  hp: number;
+  hpStorage: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/users/modules/user-hp.module.ts
+++ b/src/users/modules/user-hp.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserHpController } from '../controllers/user-hp.controller';
+import { UserHpService } from '../services/user-hp.service';
+
+@Module({
+  controllers: [UserHpController],
+  providers: [UserHpService],
+})
+export class UserHpModule {}

--- a/src/users/modules/user-hp.module.ts
+++ b/src/users/modules/user-hp.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UserHpController } from '../controllers/user-hp.controller';
 import { UserHpService } from '../services/user-hp.service';
+import { UserHpRepository } from '../repositories/user-hp.repository';
 
 @Module({
   controllers: [UserHpController],
-  providers: [UserHpService],
+  providers: [UserHpService, UserHpRepository],
 })
 export class UserHpModule {}

--- a/src/users/modules/users-core.module.ts
+++ b/src/users/modules/users-core.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UserHpModule } from './user-hp.module';
+import { UsersModule } from './users.module';
+import { UserPointModule } from './user-point.module';
+import { UserExperienceModule } from './user-experience.module';
+
+@Module({
+  imports: [UserExperienceModule, UserPointModule, UserHpModule, UsersModule],
+})
+export class UsersCoreModule {}

--- a/src/users/modules/users.module.ts
+++ b/src/users/modules/users.module.ts
@@ -4,7 +4,6 @@ import { UsersService } from '../services/users.service';
 import { UserHpModule } from './user-hp.module';
 
 @Module({
-  imports: [UserHpModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/modules/users.module.ts
+++ b/src/users/modules/users.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from '../controllers/users.controller';
 import { UsersService } from '../services/users.service';
+import { UserHpModule } from './user-hp.module';
 
 @Module({
+  imports: [UserHpModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/repositories/user-hp.repository.ts
+++ b/src/users/repositories/user-hp.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class UserHpRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findUserHpByUserId(userId: number) {
+    return this.prisma.userHp.findUnique({
+      where: { userId },
+    });
+  }
+  async updateUserHpByUserId(userId: number, data: any) {
+    return this.prisma.userHp.update({
+      where: { userId },
+      data,
+    });
+  }
+}

--- a/src/users/repositories/user-hp.repository.ts
+++ b/src/users/repositories/user-hp.repository.ts
@@ -12,6 +12,7 @@ export class UserHpRepository {
       where: { userId },
     });
   }
+
   async updateUserHpByUserId(
     userId: number,
     data: UpdateHpDto,

--- a/src/users/repositories/user-hp.repository.ts
+++ b/src/users/repositories/user-hp.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { UpdateHpDto } from '../dtos/update-hp.dto';
 
 @Injectable()
 export class UserHpRepository {
@@ -10,7 +11,7 @@ export class UserHpRepository {
       where: { userId },
     });
   }
-  async updateUserHpByUserId(userId: number, data: any) {
+  async updateUserHpByUserId(userId: number, data: UpdateHpDto) {
     return this.prisma.userHp.update({
       where: { userId },
       data,

--- a/src/users/repositories/user-hp.repository.ts
+++ b/src/users/repositories/user-hp.repository.ts
@@ -1,17 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
+import { UserHp } from '../entities/user-hp.entity';
 
 @Injectable()
 export class UserHpRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findUserHpByUserId(userId: number) {
+  async findUserHpByUserId(userId: number): Promise<UserHp> {
     return this.prisma.userHp.findUnique({
       where: { userId },
     });
   }
-  async updateUserHpByUserId(userId: number, data: UpdateHpDto) {
+  async updateUserHpByUserId(
+    userId: number,
+    data: UpdateHpDto,
+  ): Promise<UserHp> {
     return this.prisma.userHp.update({
       where: { userId },
       data,

--- a/src/users/services/user-hp.service.spec.ts
+++ b/src/users/services/user-hp.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserHpService } from './user-hp.service';
+
+describe('UserHpService', () => {
+  let service: UserHpService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserHpService],
+    }).compile();
+
+    service = module.get<UserHpService>(UserHpService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class UserHpService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findUserHpByUserId(userId: number) {
+    return;
+  }
+  async updateUserHpByUserId(userId: number, body: any) {
+    return;
+  }
+}

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { UserHpRepository } from '../repositories/user-hp.repository';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
 
@@ -7,9 +11,23 @@ export class UserHpService {
   constructor(private readonly userHpRepository: UserHpRepository) {}
 
   async findUserHpByUserId(userId: number) {
-    return this.userHpRepository.findUserHpByUserId(userId);
+    const user = await this.userHpRepository.findUserHpByUserId(userId);
+
+    if (!user) {
+      throw new NotFoundException(`id ${userId} not found`);
+    }
+
+    return user;
   }
   async updateUserHpByUserId(userId: number, body: UpdateHpDto) {
+    const { hp } = body;
+    const { hpStorage } = await this.findUserHpByUserId(userId);
+
+    if (hp > hpStorage) {
+      throw new BadRequestException(
+        `hp(${hp})는 hpStorage(${hpStorage})보다 작아야 합니다.`,
+      );
+    }
     return this.userHpRepository.updateUserHpByUserId(userId, body);
   }
 }

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -5,12 +5,13 @@ import {
 } from '@nestjs/common';
 import { UserHpRepository } from '../repositories/user-hp.repository';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
+import { UserHp } from '../entities/user-hp.entity';
 
 @Injectable()
 export class UserHpService {
   constructor(private readonly userHpRepository: UserHpRepository) {}
 
-  async findUserHpByUserId(userId: number) {
+  async findUserHpByUserId(userId: number): Promise<UserHp> {
     const user = await this.userHpRepository.findUserHpByUserId(userId);
 
     if (!user) {
@@ -19,7 +20,10 @@ export class UserHpService {
 
     return user;
   }
-  async updateUserHpByUserId(userId: number, body: UpdateHpDto) {
+  async updateUserHpByUserId(
+    userId: number,
+    body: UpdateHpDto,
+  ): Promise<UserHp> {
     const { hp } = body;
     const { hpStorage } = await this.findUserHpByUserId(userId);
 

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { UserHpRepository } from '../repositories/user-hp.repository';
+import { UpdateHpDto } from '../dtos/update-hp.dto';
 
 @Injectable()
 export class UserHpService {
@@ -9,7 +9,7 @@ export class UserHpService {
   async findUserHpByUserId(userId: number) {
     return this.userHpRepository.findUserHpByUserId(userId);
   }
-  async updateUserHpByUserId(userId: number, body: any) {
+  async updateUserHpByUserId(userId: number, body: UpdateHpDto) {
     return this.userHpRepository.updateUserHpByUserId(userId, body);
   }
 }

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { UserHpRepository } from '../repositories/user-hp.repository';
 
 @Injectable()
 export class UserHpService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly userHpRepository: UserHpRepository) {}
 
   async findUserHpByUserId(userId: number) {
-    return;
+    return this.userHpRepository.findUserHpByUserId(userId);
   }
   async updateUserHpByUserId(userId: number, body: any) {
-    return;
+    return this.userHpRepository.updateUserHpByUserId(userId, body);
   }
 }

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -6,32 +6,57 @@ import {
 import { UserHpRepository } from '../repositories/user-hp.repository';
 import { UpdateHpDto } from '../dtos/update-hp.dto';
 import { UserHp } from '../entities/user-hp.entity';
+import { HP_FULL_RECHARGE_TIME } from '../constants/user-experience.constant';
 
 @Injectable()
 export class UserHpService {
   constructor(private readonly userHpRepository: UserHpRepository) {}
 
-  async findUserHpByUserId(userId: number): Promise<UserHp> {
-    const user = await this.userHpRepository.findUserHpByUserId(userId);
+  private async checkRefillTime({ updatedAt }: UserHp) {
+    const lastUpdated = new Date(updatedAt);
+    const now = new Date();
+    const timeDiff = now.getTime() - lastUpdated.getTime();
 
-    if (!user) {
-      throw new NotFoundException(`id ${userId} not found`);
+    if (timeDiff >= HP_FULL_RECHARGE_TIME) {
+      return true;
     }
 
-    return user;
+    return false;
+  }
+
+  async findUserHpByUserId(userId: number): Promise<UserHp> {
+    const userHp = await this.userHpRepository.findUserHpByUserId(userId);
+
+    if (!userHp) {
+      throw new NotFoundException(`id ${userId}'s HP not found`);
+    }
+
+    // 생명력을 가득 채워야하는지 체크
+    const chackRechargeHp = await this.checkRefillTime(userHp);
+
+    // 채워야 하면
+    if (chackRechargeHp) {
+      // hp를 hpStorage만큼 채움
+      const newBody: UpdateHpDto = { hp: userHp.hpStorage };
+      return this.userHpRepository.updateUserHpByUserId(userId, newBody);
+    }
+
+    return userHp;
   }
   async updateUserHpByUserId(
     userId: number,
     body: UpdateHpDto,
   ): Promise<UserHp> {
     const { hp } = body;
-    const { hpStorage } = await this.findUserHpByUserId(userId);
+    const userHp = await this.findUserHpByUserId(userId);
+    const hpStorage = userHp.hpStorage;
 
     if (hp > hpStorage) {
       throw new BadRequestException(
         `hp(${hp})는 hpStorage(${hpStorage})보다 작아야 합니다.`,
       );
     }
+
     return this.userHpRepository.updateUserHpByUserId(userId, body);
   }
 }

--- a/src/users/services/user-hp.service.ts
+++ b/src/users/services/user-hp.service.ts
@@ -12,7 +12,7 @@ import { HP_FULL_RECHARGE_TIME } from '../constants/user-experience.constant';
 export class UserHpService {
   constructor(private readonly userHpRepository: UserHpRepository) {}
 
-  private async checkRefillTime({ updatedAt }: UserHp) {
+  private checkRefillTime({ updatedAt }: UserHp): boolean {
     const lastUpdated = new Date(updatedAt);
     const now = new Date();
     const timeDiff = now.getTime() - lastUpdated.getTime();
@@ -32,7 +32,7 @@ export class UserHpService {
     }
 
     // 생명력을 가득 채워야하는지 체크
-    const chackRechargeHp = await this.checkRefillTime(userHp);
+    const chackRechargeHp = this.checkRefillTime(userHp);
 
     // 채워야 하면
     if (chackRechargeHp) {

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -42,14 +42,14 @@ export class UsersService {
     // 유저 생성시 디폴트 파트 진행도를 생성
     const defaulPartProgress = await this.createDefaultPartProgress();
 
+    // 유저 생성시 기본 유저 생명력 생성
     const userResponse = await this.prisma.user.create({
       data: {
         provider,
         providerId,
         name,
-        partProgress: {
-          create: defaulPartProgress,
-        },
+        partProgress: { create: defaulPartProgress },
+        userHp: { create: {} },
       },
     });
 

--- a/src/users/swaggers/user-hp.swagger.ts
+++ b/src/users/swaggers/user-hp.swagger.ts
@@ -1,0 +1,49 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { HP_FULL_RECHARGE_TIME } from '../constants/user-experience.constant';
+import { ResUserHpDto } from '../dtos/res-user-hp.dto';
+
+export const ApiUserHp = {
+  getUserHp: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '인증된 유저의 hp정보 조회',
+        description: `
+        1. 유저 id, 유저 hp, 유저 hpStorage(최대 hp통)를 보여줌
+        2. GET 요청은 유저hp 리차지의 트리거로 사용됨
+        3. 유저 생명력 업데이트 후 ${HP_FULL_RECHARGE_TIME / 60 / 1000}분 이 지나면
+           GET 요청으로 생명력 조회시 생명력이 hpStorage 수치까지 가득참
+        `,
+      }),
+      ApiResponse({
+        status: 200,
+        description: `
+          유저 id, 유저 hp, 유저 hpStorage(최대 hp통)를 보여줌
+        `,
+        type: ResUserHpDto,
+      }),
+    );
+  },
+  updateUserHp: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '유저의 파트에 대한 진행도생성 또는 업데이트',
+        description: `
+        1. 유저 hp, 유저 hpStorage(최대 hp통)를 수정 할 수 있음
+        2. 두개의 옵션(hp, hpStorage) 중 하나 이상을 넣으면 됨 
+        3. 두 값은 number 값을 넣어야함
+        4. 두 값은 min 0
+        5. hp값은 hpStorage값을 넘을 수 없음
+        6. 유저 생명력 업데이트 후 ${HP_FULL_RECHARGE_TIME / 60 / 1000}분 이 지나면
+           GET 요청으로 생명력 조회시 생명력이 hpStorage 수치까지 가득참
+        `,
+      }),
+      ApiResponse({
+        status: 200,
+        description:
+          '수정이 완료되면 유저 id와 수정된 유저 hp, 유저 hpStorage(최대 hp통)를 보여줌',
+        type: ResUserHpDto,
+      }),
+    );
+  },
+};


### PR DESCRIPTION
## 🔗 관련 이슈

#61 

## 📝작업 내용
<img width="295" alt="image" src="https://github.com/user-attachments/assets/c257a508-8b22-4d83-b476-edda44fea433" />

cokoedu의 유저 생명력 관련 api 입니다. 이번 api 부터 유저id를 url 로 받지 않고 토큰에서 유저 id를 받도록 바꿨습니다.

**1. GET users/user-hp**
유저 생명력을 조회합니다.
유저id, 유저hp, 유저hp storage(최대생명력)을 보여줍니다.

이 get 요청은 유저 생명력 리차지의 이벤트 트리거로 사용됩니다.

**2. PATCH users/user-hp**
유저hp, 유저hp storage 두 가지를 옵셔널로 받아 수정합니다.
두 값은 최소 0 , hp는 최대 hpStorage 값을 줄 수 있습니다. 자세한 내용은 스웨거 참조

**3. 유저 생명력 최대로 채우기**
유저 생명력 업데이트 후 20분 이 지나면 
get 요청시 유저 hp 를 hpStorage값으로 올립니다. (리차지)

**4. user 관련 모듈들의 요청 흐름을 위해 모듈들을 정리했습니다.**
app모듈 -> user core모듈 -> users모듈
                                          -> user-hp모듈
                                          -> user-경험치 모듈
                                          -> user-포인트 모듈

-> 방향은 의존성입니다.

**5. user-hp 모델생성 및 user모델 수정**
마이그레이트 디렉토리 3개가 추가 되었습니다. 
develop에 pr합쳐진 후 pull 하시기 전에 user테이블 비우고 하셔야합니다. (데이터 날라감)

user-hp 테이블은 user 삭제시 Cascade 옵션입니다.

**6. 마지막으로 user-hp 테이블의 레코드는 
유저 생성시 자동으로 생성됩니다. (트랜젝션 완료)**

## 🔍 변경 사항

- [x] GET users/user-hp
- [x] PATCH users/user-hp
- [x] 모듈 import 정리, 유저 모델 변경

## 💬리뷰 요구사항 (선택사항)
