### PR TITLE
access토큰값을 넣는 스웨거 authorize 버튼(쿠키)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ async function bootstrap() {
     )
     .addServer('https://api.cokoedu.com', 'develop') // develop 서버
     .addServer('http://localhost:3000', 'local') // 로컬 서버
+    .addCookieAuth('accessToken')
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,19 @@ async function bootstrap() {
   SwaggerModule.setup('api', app, document, {
     swaggerOptions: {
       persistAuthorization: true, // Swagger UI에서 인증 정보를 유지
+      // Swagger UI에서 보여줄 API 순서 정렬
+      operationsSorter: (a: any, b: any) => {
+        //메서드 순서
+        const order = {
+          get: '0',
+          post: '1',
+          put: '2',
+          patch: '3',
+          delete: '4',
+        };
+
+        return order[a.get('method')].localeCompare(order[b.get('method')]);
+      },
     },
   });
 

--- a/src/users/controllers/user-hp.controller.ts
+++ b/src/users/controllers/user-hp.controller.ts
@@ -7,7 +7,7 @@ import { User } from 'src/common/decorators/get-user.decorator';
 import { ResUserHpDto } from '../dtos/res-user-hp.dto';
 import { ApiUserHp } from '../swaggers/user-hp.swagger';
 
-@ApiTags('user-hp')
+@ApiTags('users')
 @Controller('users/user-hp')
 export class UserHpController {
   constructor(private readonly userHpService: UserHpService) {}

--- a/src/users/dtos/res-user-hp.dto.ts
+++ b/src/users/dtos/res-user-hp.dto.ts
@@ -1,8 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserHp } from '../entities/user-hp.entity';
 
 export class ResUserHpDto {
+  @ApiProperty({ example: 12 })
   readonly userId: number;
+
+  @ApiProperty({ example: 3 })
   readonly hp: number;
+
+  @ApiProperty({ example: 5 })
   readonly hpStorage: number;
 
   constructor(userHp: UserHp) {

--- a/src/users/dtos/update-hp.dto.ts
+++ b/src/users/dtos/update-hp.dto.ts
@@ -17,7 +17,6 @@ export class UpdateHpDto {
   readonly hp?: number;
 
   @ApiProperty({
-    required: true,
     description:
       '유저의 최대 생명력 수치, 디폴트 5이기 때문에 최소 5값을 가져야함',
     example: 5,

--- a/src/users/swaggers/user-hp.swagger.ts
+++ b/src/users/swaggers/user-hp.swagger.ts
@@ -1,11 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { HP_FULL_RECHARGE_TIME } from '../constants/user-experience.constant';
 import { ResUserHpDto } from '../dtos/res-user-hp.dto';
 
 export const ApiUserHp = {
   getUserHp: () => {
     return applyDecorators(
+      ApiCookieAuth('accessToken'),
       ApiOperation({
         summary: '인증된 유저의 hp정보 조회',
         description: `
@@ -26,6 +27,7 @@ export const ApiUserHp = {
   },
   updateUserHp: () => {
     return applyDecorators(
+      ApiCookieAuth('accessToken'),
       ApiOperation({
         summary: '유저의 파트에 대한 진행도생성 또는 업데이트',
         description: `


### PR DESCRIPTION
## 🔗 관련 이슈

#63 

## 📝작업 내용

### 1. 스웨거UI에 인증버튼 생성되었습니다. auth/google에서 받은 쿠키에서 access 토큰 값을 넣어야합니다.
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/8fb1b53a-1a17-4f6b-b865-16dda29d8b87" />
<img width="657" alt="image" src="https://github.com/user-attachments/assets/2f646c68-2389-402f-abe0-744b591b2450" />


### 2. user-hp 컨트롤러의 엔드포인트 메서드들에 쿠키인증이 필요한걸 스웨거 문서에 적어봤습니다.

```ts
export const ApiUserHp = {
  getUserHp: () => {
    return applyDecorators(
      ApiCookieAuth('accessToken'),    <-이거 적용했음
      ApiOperation({
        summary: '인증된 유저의 hp정보 조회',
        description: `
        1. 유저 id, 유저 hp, 유저 hpStorage(최대 hp통)를 보여줌
        2. GET 요청은 유저hp 리차지의 트리거로 사용됨
        3. 유저 생명력 업데이트 후 ${HP_FULL_RECHARGE_TIME / 60 / 1000}분 이 지나면
           GET 요청으로 생명력 조회시 생명력이 hpStorage 수치까지 가득참
        `,
      }),
```

### 3. 스웨거 api가 메서드 별로 정렬되게 했습니다.
<img width="812" alt="image" src="https://github.com/user-attachments/assets/1037a98a-0885-4440-ba42-7bd5e1e2b066" />


## 🔍 변경 사항

- 

## 💬리뷰 요구사항 (선택사항)
