### PR TITLE
GET /section/id 에서 찾을 수 없는 404상태에 500으로 띄우던 에러 수정

### DIFF
--- a/src/sections/sections.service.ts
+++ b/src/sections/sections.service.ts
@@ -127,12 +127,14 @@ export class SectionsService {
    * 기존 findOneWithParts 에서 parts에 status가 들거가도록 서비스 변경
    */
   async findOneWithParts(id: number): Promise<SectionPartsStatus> {
-    const { part, ...section } =
+    const sectionWithParts =
       await this.sectionsRepository.findSectionWithPartsById(id);
 
-    if (!section) {
+    if (!sectionWithParts) {
       throw new NotFoundException();
     }
+
+    const { part, ...section } = sectionWithParts;
 
     // ropository에서 받은 값 중 part를 정리하는 코드
     const newParts = part.map((part) => {


### PR DESCRIPTION
## 🔗 관련 이슈

#74 

## 📝작업 내용

404를 띄워야 하는데 로직상 문제가 있어서 500이 뜨던 문제를 해결합니다.

## 🔍 변경 사항

- [ ] 메소드 리턴값에 바로 구조분해할당 하던걸 변경
## 💬리뷰 요구사항 (선택사항)
