### PR TITLE
section 엔드포인트 순서변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN}}
+          password: ${{ secrets.GHCR_TOKEN_DG1418}}
 
       # Build 및 push
       - name: Build and push
@@ -61,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN_DG1418 }}
 
       # 앱 이미지 이름 업데이트
       - name: Update DOCKER_IMAGE in .env file

--- a/src/common/pipes/positive-int/positive-int.pipe.ts
+++ b/src/common/pipes/positive-int/positive-int.pipe.ts
@@ -11,7 +11,7 @@ export class PositiveIntPipe extends ParseIntPipe {
     const parseInt = await super.transform(value, metadata);
 
     if (parseInt < 0) {
-      throw new BadRequestException();
+      throw new BadRequestException('들어온 url id값이 number가 아닙니다.');
     }
 
     return parseInt;

--- a/src/sections/sections.controller.ts
+++ b/src/sections/sections.controller.ts
@@ -34,6 +34,14 @@ export class SectionsController {
     return ResSectionDto.fromArray(sections);
   }
 
+  @ApiSections.findAllPaginatedSectionsWithParts()
+  @Get('parts')
+  async findAllPaginatedSectionsWithParts(@Query() query: QuerySectionDto) {
+    const PaginatedSectionWithParts =
+      await this.sectionsService.findAllWithParts(query);
+    return new ResPaginationOfSectionPartsDto(PaginatedSectionWithParts);
+  }
+
   /**
    * 기존 findOne 다시 복구
    * 추가로 ResSectionPartsDto가 status도 확인하게 바뀌어서 관련된 값이 들어오도록 변경
@@ -46,14 +54,6 @@ export class SectionsController {
   ): Promise<ResSectionPartsDto> {
     const sectionWithParts = await this.sectionsService.findOneWithParts(id);
     return new ResSectionPartsDto(sectionWithParts);
-  }
-
-  @ApiSections.findAllPaginatedSectionsWithParts()
-  @Get('parts')
-  async findAllPaginatedSectionsWithParts(@Query() query: QuerySectionDto) {
-    const PaginatedSectionWithParts =
-      await this.sectionsService.findAllWithParts(query);
-    return new ResPaginationOfSectionPartsDto(PaginatedSectionWithParts);
   }
 
   @ApiSections.create()


### PR DESCRIPTION
## 🔗 관련 이슈

#80 

## 📝작업 내용

section/parts 요청이 section/:id 엔드포인트로 받아지는 버그가 생겼습니다
컨트롤러에서 엔드포인트 순서를 변경해 해결하는 pr 입니다.

## 🔍 변경 사항

- [ ] 엔드포인트 순서 변경

## 💬리뷰 요구사항 (선택사항)
