### PR TITLE
일일퀘스트 기본 crud 작성

### DIFF
--- a/prisma/migrations/20250122075156_daily_quest_create/migration.sql
+++ b/prisma/migrations/20250122075156_daily_quest_create/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "daily_quests" (
+    "id" SERIAL NOT NULL,
+    "title" VARCHAR(50) NOT NULL,
+    "content" VARCHAR(255) NOT NULL,
+    "point" INTEGER NOT NULL,
+    "exp" INTEGER NOT NULL,
+    "condition" INTEGER NOT NULL,
+
+    CONSTRAINT "daily_quests_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20250122085602_add_created_at_updated_at/migration.sql
+++ b/prisma/migrations/20250122085602_add_created_at_updated_at/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `updated_at` to the `daily_quests` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "daily_quests" ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,3 +176,14 @@ model AdminUser {
 
   @@map("admin_users")
 }
+
+model DailyQuest {
+  id        Int    @id @default(autoincrement())
+  title     String @db.VarChar(50)
+  content   String @db.VarChar(255)
+  point     Int
+  exp       Int
+  condition Int
+
+  @@map("daily_quests")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,12 +178,14 @@ model AdminUser {
 }
 
 model DailyQuest {
-  id        Int    @id @default(autoincrement())
-  title     String @db.VarChar(50)
-  content   String @db.VarChar(255)
+  id        Int      @id @default(autoincrement())
+  title     String   @db.VarChar(50)
+  content   String   @db.VarChar(255)
   point     Int
   exp       Int
   condition Int
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("daily_quests")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { AppController } from './app.controller';
 import { UsersCoreModule } from './users/modules/users-core.module';
 import { AdminModule } from './admin/admin.module';
+import { DailyQuestsModule } from './daily-quests/daily-quests.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { AdminModule } from './admin/admin.module';
     ItemsModule,
     AuthModule,
     AdminModule,
+    DailyQuestsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/daily-quests/daily-quest.swagger.ts
+++ b/src/daily-quests/daily-quest.swagger.ts
@@ -11,8 +11,7 @@ export const ApiDailyQuest = {
       ApiResponse({
         status: 200,
         description: '일일퀘스트 전체를 모두 조회',
-        type: ResDailyQuestDto,
-        isArray: true,
+        type: [ResDailyQuestDto],
       }),
     );
   },

--- a/src/daily-quests/daily-quest.swagger.ts
+++ b/src/daily-quests/daily-quest.swagger.ts
@@ -1,0 +1,103 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ResDailyQuestDto } from './dto/res-daily-quest.dto';
+
+export const ApiDailyQuest = {
+  findAll: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '모두 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '일일퀘스트 전체를 모두 조회',
+        type: ResDailyQuestDto,
+        isArray: true,
+      }),
+    );
+  },
+  findOne: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: 'id로 하나 조회',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '일일퀘스트 하나를 id값으로 조회',
+        type: ResDailyQuestDto,
+      }),
+      ApiResponse({
+        status: 404,
+        description: '일일퀘스트 id를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: '일일퀘스트 12를 찾을 수 없습니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+    );
+  },
+  create: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '생성',
+      }),
+      ApiResponse({
+        status: 204,
+        description: '새 일일퀘스트가 성공적으로 생성',
+      }),
+    );
+  },
+  update: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '수정',
+      }),
+      ApiResponse({
+        status: 204,
+        description: '일일퀘스트가 성공적으로 수정',
+      }),
+      ApiResponse({
+        status: 404,
+        description: '일일퀘스트 id를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: '일일퀘스트 12를 찾을 수 없습니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+    );
+  },
+  remove: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '삭제',
+      }),
+      ApiResponse({
+        status: 204,
+        description: '일일퀘스트가 성공적으로 삭제',
+      }),
+      ApiResponse({
+        status: 404,
+        description: '일일퀘스트 id를 찾을 수 없음',
+        content: {
+          JSON: {
+            example: {
+              message: '일일퀘스트 12를 찾을 수 없습니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      }),
+    );
+  },
+};

--- a/src/daily-quests/daily-quests.controller.spec.ts
+++ b/src/daily-quests/daily-quests.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyQuestsController } from './daily-quests.controller';
+import { DailyQuestsService } from './daily-quests.service';
+
+describe('DailyQuestsController', () => {
+  let controller: DailyQuestsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DailyQuestsController],
+      providers: [DailyQuestsService],
+    }).compile();
+
+    controller = module.get<DailyQuestsController>(DailyQuestsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -7,45 +7,52 @@ import {
   Param,
   Delete,
   UseGuards,
+  HttpCode,
 } from '@nestjs/common';
 import { DailyQuestsService } from './daily-quests.service';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { AuthGuard } from '@nestjs/passport';
+import { ResDailyQuestDto } from './dto/res-daily-quest.dto';
 
 @Controller('daily-quests')
 export class DailyQuestsController {
   constructor(private readonly dailyQuestsService: DailyQuestsService) {}
 
   @Get()
-  findAll() {
-    return this.dailyQuestsService.findAll();
+  async findAll() {
+    const dailyQuests = await this.dailyQuestsService.findAll();
+    return ResDailyQuestDto.fromArray(dailyQuests);
   }
 
   @Get(':questId')
-  findOne(@Param('questId', PositiveIntPipe) questId: number) {
-    return this.dailyQuestsService.findOne(questId);
+  async findOne(@Param('questId', PositiveIntPipe) questId: number) {
+    const dailyQuest = await this.dailyQuestsService.findOne(questId);
+    return new ResDailyQuestDto(dailyQuest);
   }
 
   @Post()
+  @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
-  create(@Body() body: CreateDailyQuestDto) {
-    return this.dailyQuestsService.create(body);
+  async create(@Body() body: CreateDailyQuestDto) {
+    await this.dailyQuestsService.create(body);
   }
 
   @Patch(':questId')
+  @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
-  update(
+  async update(
     @Param('questId', PositiveIntPipe) questId: number,
     @Body() body: UpdateDailyQuestDto,
   ) {
-    return this.dailyQuestsService.update(questId, body);
+    await this.dailyQuestsService.update(questId, body);
   }
 
   @Delete(':questId')
+  @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
-  remove(@Param('questId', PositiveIntPipe) questId: number) {
-    return this.dailyQuestsService.remove(questId);
+  async remove(@Param('questId', PositiveIntPipe) questId: number) {
+    await this.dailyQuestsService.remove(questId);
   }
 }

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -6,11 +6,13 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { DailyQuestsService } from './daily-quests.service';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('daily-quests')
 export class DailyQuestsController {
@@ -27,11 +29,13 @@ export class DailyQuestsController {
   }
 
   @Post()
+  @UseGuards(AuthGuard('adminAccessToken'))
   create(@Body() body: CreateDailyQuestDto) {
     return this.dailyQuestsService.create(body);
   }
 
   @Patch(':questId')
+  @UseGuards(AuthGuard('adminAccessToken'))
   update(
     @Param('questId', PositiveIntPipe) questId: number,
     @Body() body: UpdateDailyQuestDto,
@@ -40,6 +44,7 @@ export class DailyQuestsController {
   }
 
   @Delete(':questId')
+  @UseGuards(AuthGuard('adminAccessToken'))
   remove(@Param('questId', PositiveIntPipe) questId: number) {
     return this.dailyQuestsService.remove(questId);
   }

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -15,24 +15,30 @@ import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { AuthGuard } from '@nestjs/passport';
 import { ResDailyQuestDto } from './dto/res-daily-quest.dto';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiDailyQuest } from './daily-quest.swagger';
 
+@ApiTags('daily-quests')
 @Controller('daily-quests')
 export class DailyQuestsController {
   constructor(private readonly dailyQuestsService: DailyQuestsService) {}
 
   @Get()
+  @ApiDailyQuest.findAll()
   async findAll() {
     const dailyQuests = await this.dailyQuestsService.findAll();
     return ResDailyQuestDto.fromArray(dailyQuests);
   }
 
   @Get(':questId')
+  @ApiDailyQuest.findOne()
   async findOne(@Param('questId', PositiveIntPipe) questId: number) {
     const dailyQuest = await this.dailyQuestsService.findOne(questId);
     return new ResDailyQuestDto(dailyQuest);
   }
 
   @Post()
+  @ApiDailyQuest.create()
   @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
   async create(@Body() body: CreateDailyQuestDto) {
@@ -40,6 +46,7 @@ export class DailyQuestsController {
   }
 
   @Patch(':questId')
+  @ApiDailyQuest.update()
   @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
   async update(
@@ -50,6 +57,7 @@ export class DailyQuestsController {
   }
 
   @Delete(':questId')
+  @ApiDailyQuest.remove()
   @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
   async remove(@Param('questId', PositiveIntPipe) questId: number) {

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { DailyQuestsService } from './daily-quests.service';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
@@ -6,11 +14,6 @@ import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 @Controller('daily-quests')
 export class DailyQuestsController {
   constructor(private readonly dailyQuestsService: DailyQuestsService) {}
-
-  @Post()
-  create(@Body() createDailyQuestDto: CreateDailyQuestDto) {
-    return this.dailyQuestsService.create(createDailyQuestDto);
-  }
 
   @Get()
   findAll() {
@@ -22,8 +25,16 @@ export class DailyQuestsController {
     return this.dailyQuestsService.findOne(+id);
   }
 
+  @Post()
+  create(@Body() createDailyQuestDto: CreateDailyQuestDto) {
+    return this.dailyQuestsService.create(createDailyQuestDto);
+  }
+
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateDailyQuestDto: UpdateDailyQuestDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updateDailyQuestDto: UpdateDailyQuestDto,
+  ) {
     return this.dailyQuestsService.update(+id, updateDailyQuestDto);
   }
 

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -10,6 +10,7 @@ import {
 import { DailyQuestsService } from './daily-quests.service';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
+import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 
 @Controller('daily-quests')
 export class DailyQuestsController {
@@ -20,26 +21,26 @@ export class DailyQuestsController {
     return this.dailyQuestsService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.dailyQuestsService.findOne(+id);
+  @Get(':questId')
+  findOne(@Param('questId', PositiveIntPipe) questId: number) {
+    return this.dailyQuestsService.findOne(questId);
   }
 
   @Post()
-  create(@Body() createDailyQuestDto: CreateDailyQuestDto) {
-    return this.dailyQuestsService.create(createDailyQuestDto);
+  create(@Body() body: CreateDailyQuestDto) {
+    return this.dailyQuestsService.create(body);
   }
 
-  @Patch(':id')
+  @Patch(':questId')
   update(
-    @Param('id') id: string,
-    @Body() updateDailyQuestDto: UpdateDailyQuestDto,
+    @Param('questId', PositiveIntPipe) questId: number,
+    @Body() body: UpdateDailyQuestDto,
   ) {
-    return this.dailyQuestsService.update(+id, updateDailyQuestDto);
+    return this.dailyQuestsService.update(questId, body);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.dailyQuestsService.remove(+id);
+  @Delete(':questId')
+  remove(@Param('questId', PositiveIntPipe) questId: number) {
+    return this.dailyQuestsService.remove(questId);
   }
 }

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -25,14 +25,16 @@ export class DailyQuestsController {
 
   @Get()
   @ApiDailyQuest.findAll()
-  async findAll() {
+  async findAll(): Promise<ResDailyQuestDto[]> {
     const dailyQuests = await this.dailyQuestsService.findAll();
     return ResDailyQuestDto.fromArray(dailyQuests);
   }
 
   @Get(':questId')
   @ApiDailyQuest.findOne()
-  async findOne(@Param('questId', PositiveIntPipe) questId: number) {
+  async findOne(
+    @Param('questId', PositiveIntPipe) questId: number,
+  ): Promise<ResDailyQuestDto> {
     const dailyQuest = await this.dailyQuestsService.findOne(questId);
     return new ResDailyQuestDto(dailyQuest);
   }
@@ -41,7 +43,7 @@ export class DailyQuestsController {
   @ApiDailyQuest.create()
   @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
-  async create(@Body() body: CreateDailyQuestDto) {
+  async create(@Body() body: CreateDailyQuestDto): Promise<void> {
     await this.dailyQuestsService.create(body);
   }
 
@@ -52,7 +54,7 @@ export class DailyQuestsController {
   async update(
     @Param('questId', PositiveIntPipe) questId: number,
     @Body() body: UpdateDailyQuestDto,
-  ) {
+  ): Promise<void> {
     await this.dailyQuestsService.update(questId, body);
   }
 
@@ -60,7 +62,9 @@ export class DailyQuestsController {
   @ApiDailyQuest.remove()
   @HttpCode(204)
   @UseGuards(AuthGuard('adminAccessToken'))
-  async remove(@Param('questId', PositiveIntPipe) questId: number) {
+  async remove(
+    @Param('questId', PositiveIntPipe) questId: number,
+  ): Promise<void> {
     await this.dailyQuestsService.remove(questId);
   }
 }

--- a/src/daily-quests/daily-quests.controller.ts
+++ b/src/daily-quests/daily-quests.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { DailyQuestsService } from './daily-quests.service';
+import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
+import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
+
+@Controller('daily-quests')
+export class DailyQuestsController {
+  constructor(private readonly dailyQuestsService: DailyQuestsService) {}
+
+  @Post()
+  create(@Body() createDailyQuestDto: CreateDailyQuestDto) {
+    return this.dailyQuestsService.create(createDailyQuestDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.dailyQuestsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.dailyQuestsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateDailyQuestDto: UpdateDailyQuestDto) {
+    return this.dailyQuestsService.update(+id, updateDailyQuestDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.dailyQuestsService.remove(+id);
+  }
+}

--- a/src/daily-quests/daily-quests.interpace.ts
+++ b/src/daily-quests/daily-quests.interpace.ts
@@ -1,7 +1,7 @@
 export interface DailyQuest {
   id: number;
-  title: String;
-  content: String;
+  title: string;
+  content: string;
   point: number;
   exp: number;
   condition: number;

--- a/src/daily-quests/daily-quests.interpace.ts
+++ b/src/daily-quests/daily-quests.interpace.ts
@@ -1,0 +1,8 @@
+export interface DailyQuestModel {
+  id: number;
+  title: String;
+  content: String;
+  point: number;
+  exp: number;
+  condition: number;
+}

--- a/src/daily-quests/daily-quests.interpace.ts
+++ b/src/daily-quests/daily-quests.interpace.ts
@@ -1,4 +1,4 @@
-export interface DailyQuestModel {
+export interface DailyQuest {
   id: number;
   title: String;
   content: String;

--- a/src/daily-quests/daily-quests.interpace.ts
+++ b/src/daily-quests/daily-quests.interpace.ts
@@ -5,4 +5,6 @@ export interface DailyQuestModel {
   point: number;
   exp: number;
   condition: number;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/daily-quests/daily-quests.module.ts
+++ b/src/daily-quests/daily-quests.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DailyQuestsService } from './daily-quests.service';
 import { DailyQuestsController } from './daily-quests.controller';
+import { DailyQuestsRepository } from './daily-quests.repository';
 
 @Module({
   controllers: [DailyQuestsController],
-  providers: [DailyQuestsService],
+  providers: [DailyQuestsService, DailyQuestsRepository],
 })
 export class DailyQuestsModule {}

--- a/src/daily-quests/daily-quests.module.ts
+++ b/src/daily-quests/daily-quests.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DailyQuestsService } from './daily-quests.service';
+import { DailyQuestsController } from './daily-quests.controller';
+
+@Module({
+  controllers: [DailyQuestsController],
+  providers: [DailyQuestsService],
+})
+export class DailyQuestsModule {}

--- a/src/daily-quests/daily-quests.repository.ts
+++ b/src/daily-quests/daily-quests.repository.ts
@@ -2,33 +2,34 @@ import { Injectable } from '@nestjs/common';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { DailyQuest } from './daily-quests.interpace';
 
 @Injectable()
 export class DailyQuestsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll() {
+  async findAll(): Promise<DailyQuest[]> {
     return this.prisma.dailyQuest.findMany();
   }
 
-  async findOne(id: number) {
+  async findOne(id: number): Promise<DailyQuest> {
     return this.prisma.dailyQuest.findUnique({
       where: { id },
     });
   }
 
-  async create(data: CreateDailyQuestDto) {
+  async create(data: CreateDailyQuestDto): Promise<DailyQuest> {
     return this.prisma.dailyQuest.create({ data });
   }
 
-  async update(id: number, data: UpdateDailyQuestDto) {
+  async update(id: number, data: UpdateDailyQuestDto): Promise<DailyQuest> {
     return this.prisma.dailyQuest.update({
       where: { id },
       data,
     });
   }
 
-  async remove(id: number) {
+  async remove(id: number): Promise<DailyQuest> {
     return this.prisma.dailyQuest.delete({
       where: { id },
     });

--- a/src/daily-quests/daily-quests.repository.ts
+++ b/src/daily-quests/daily-quests.repository.ts
@@ -1,10 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
-export class dailyQuestsRepository {
+export class DailyQuestsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findAll() {

--- a/src/daily-quests/daily-quests.repository.ts
+++ b/src/daily-quests/daily-quests.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
+import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class dailyQuestsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    return this.prisma.dailyQuest.findMany();
+  }
+
+  async findOne(id: number) {
+    return this.prisma.dailyQuest.findUnique({
+      where: { id },
+    });
+  }
+
+  async create(data: CreateDailyQuestDto) {
+    return this.prisma.dailyQuest.create({ data });
+  }
+
+  async update(id: number, data: UpdateDailyQuestDto) {
+    return this.prisma.dailyQuest.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async remove(id: number) {
+    return this.prisma.dailyQuest.delete({
+      where: { id },
+    });
+  }
+}

--- a/src/daily-quests/daily-quests.service.spec.ts
+++ b/src/daily-quests/daily-quests.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyQuestsService } from './daily-quests.service';
+
+describe('DailyQuestsService', () => {
+  let service: DailyQuestsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DailyQuestsService],
+    }).compile();
+
+    service = module.get<DailyQuestsService>(DailyQuestsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/daily-quests/daily-quests.service.ts
+++ b/src/daily-quests/daily-quests.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
+import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
+
+@Injectable()
+export class DailyQuestsService {
+  create(createDailyQuestDto: CreateDailyQuestDto) {
+    return 'This action adds a new dailyQuest';
+  }
+
+  findAll() {
+    return `This action returns all dailyQuests`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} dailyQuest`;
+  }
+
+  update(id: number, updateDailyQuestDto: UpdateDailyQuestDto) {
+    return `This action updates a #${id} dailyQuest`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} dailyQuest`;
+  }
+}

--- a/src/daily-quests/daily-quests.service.ts
+++ b/src/daily-quests/daily-quests.service.ts
@@ -1,26 +1,36 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 
 @Injectable()
 export class DailyQuestsService {
-  create(createDailyQuestDto: CreateDailyQuestDto) {
-    return 'This action adds a new dailyQuest';
+  constructor(private readonly dailyQuestsRepository: any) {}
+
+  async findAll() {
+    return this.dailyQuestsRepository.findAll();
   }
 
-  findAll() {
-    return `This action returns all dailyQuests`;
+  async findOne(questId: number) {
+    const dailyQuest = await this.dailyQuestsRepository.findOne(questId);
+
+    if (!dailyQuest) {
+      throw new NotFoundException(`ID ${questId} 를 찾을 수 없습니다.`);
+    }
+
+    return dailyQuest;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} dailyQuest`;
+  async create(body: CreateDailyQuestDto) {
+    return this.dailyQuestsRepository.create(body);
   }
 
-  update(id: number, updateDailyQuestDto: UpdateDailyQuestDto) {
-    return `This action updates a #${id} dailyQuest`;
+  async update(questId: number, body: UpdateDailyQuestDto) {
+    await this.findOne(questId);
+    return this.dailyQuestsRepository.update(questId, body);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} dailyQuest`;
+  async remove(questId: number) {
+    await this.findOne(questId);
+    return this.dailyQuestsRepository.remove(questId);
   }
 }

--- a/src/daily-quests/daily-quests.service.ts
+++ b/src/daily-quests/daily-quests.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
+import { DailyQuestsRepository } from './daily-quests.repository';
 
 @Injectable()
 export class DailyQuestsService {
-  constructor(private readonly dailyQuestsRepository: any) {}
+  constructor(private readonly dailyQuestsRepository: DailyQuestsRepository) {}
 
   async findAll() {
     return this.dailyQuestsRepository.findAll();

--- a/src/daily-quests/daily-quests.service.ts
+++ b/src/daily-quests/daily-quests.service.ts
@@ -2,16 +2,17 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateDailyQuestDto } from './dto/create-daily-quest.dto';
 import { UpdateDailyQuestDto } from './dto/update-daily-quest.dto';
 import { DailyQuestsRepository } from './daily-quests.repository';
+import { DailyQuest } from './daily-quests.interpace';
 
 @Injectable()
 export class DailyQuestsService {
   constructor(private readonly dailyQuestsRepository: DailyQuestsRepository) {}
 
-  async findAll() {
+  async findAll(): Promise<DailyQuest[]> {
     return this.dailyQuestsRepository.findAll();
   }
 
-  async findOne(questId: number) {
+  async findOne(questId: number): Promise<DailyQuest> {
     const dailyQuest = await this.dailyQuestsRepository.findOne(questId);
 
     if (!dailyQuest) {
@@ -21,16 +22,19 @@ export class DailyQuestsService {
     return dailyQuest;
   }
 
-  async create(body: CreateDailyQuestDto) {
+  async create(body: CreateDailyQuestDto): Promise<DailyQuest> {
     return this.dailyQuestsRepository.create(body);
   }
 
-  async update(questId: number, body: UpdateDailyQuestDto) {
+  async update(
+    questId: number,
+    body: UpdateDailyQuestDto,
+  ): Promise<DailyQuest> {
     await this.findOne(questId);
     return this.dailyQuestsRepository.update(questId, body);
   }
 
-  async remove(questId: number) {
+  async remove(questId: number): Promise<DailyQuest> {
     await this.findOne(questId);
     return this.dailyQuestsRepository.remove(questId);
   }

--- a/src/daily-quests/daily-quests.service.ts
+++ b/src/daily-quests/daily-quests.service.ts
@@ -15,7 +15,7 @@ export class DailyQuestsService {
     const dailyQuest = await this.dailyQuestsRepository.findOne(questId);
 
     if (!dailyQuest) {
-      throw new NotFoundException(`ID ${questId} 를 찾을 수 없습니다.`);
+      throw new NotFoundException(`일일퀘스트 ${questId}를 찾을 수 없습니다.`);
     }
 
     return dailyQuest;

--- a/src/daily-quests/dto/create-daily-quest.dto.ts
+++ b/src/daily-quests/dto/create-daily-quest.dto.ts
@@ -1,0 +1,1 @@
+export class CreateDailyQuestDto {}

--- a/src/daily-quests/dto/create-daily-quest.dto.ts
+++ b/src/daily-quests/dto/create-daily-quest.dto.ts
@@ -1,20 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, Min } from 'class-validator';
 
 export class CreateDailyQuestDto {
+  @ApiProperty({
+    description: '제목',
+    example: '제목',
+  })
   @IsString()
   readonly title: string;
 
+  @ApiProperty({
+    description: '내용',
+    example: '문제 5개를 푸세요',
+  })
   @IsString()
   readonly content: string;
 
+  @ApiProperty({
+    description: '보상 포인트수치',
+    example: 1000,
+  })
   @IsInt()
   @Min(0)
   readonly point: number;
 
+  @ApiProperty({
+    description: '보상 경험치수치',
+    example: 100,
+  })
   @IsInt()
   @Min(0)
   readonly exp: number;
 
+  @ApiProperty({
+    description: '달성조건',
+    example: 5,
+  })
   @IsInt()
   @Min(0)
   readonly condition: number;

--- a/src/daily-quests/dto/create-daily-quest.dto.ts
+++ b/src/daily-quests/dto/create-daily-quest.dto.ts
@@ -1,1 +1,21 @@
-export class CreateDailyQuestDto {}
+import { IsInt, IsString, Min } from 'class-validator';
+
+export class CreateDailyQuestDto {
+  @IsString()
+  readonly title: string;
+
+  @IsString()
+  readonly content: string;
+
+  @IsInt()
+  @Min(0)
+  readonly point: number;
+
+  @IsInt()
+  @Min(0)
+  readonly exp: number;
+
+  @IsInt()
+  @Min(0)
+  readonly condition: number;
+}

--- a/src/daily-quests/dto/res-daily-quest.dto.ts
+++ b/src/daily-quests/dto/res-daily-quest.dto.ts
@@ -1,0 +1,19 @@
+import { DailyQuest } from '../entities/daily-quest.entity';
+
+export class ResDailyQuestDto {
+  readonly id: number;
+  readonly title: string;
+  readonly content: string;
+  readonly point: number;
+  readonly exp: number;
+  readonly condition: number;
+
+  constructor(dailyQuest: DailyQuest) {
+    this.id = dailyQuest.id;
+    this.title = dailyQuest.title;
+    this.content = dailyQuest.content;
+    this.point = dailyQuest.point;
+    this.exp = dailyQuest.exp;
+    this.condition = dailyQuest.condition;
+  }
+}

--- a/src/daily-quests/dto/res-daily-quest.dto.ts
+++ b/src/daily-quests/dto/res-daily-quest.dto.ts
@@ -16,4 +16,8 @@ export class ResDailyQuestDto {
     this.exp = dailyQuest.exp;
     this.condition = dailyQuest.condition;
   }
+
+  static fromArray(dailyQuests: DailyQuest[]): ResDailyQuestDto[] {
+    return dailyQuests.map((dailyQuest) => new ResDailyQuestDto(dailyQuest));
+  }
 }

--- a/src/daily-quests/dto/res-daily-quest.dto.ts
+++ b/src/daily-quests/dto/res-daily-quest.dto.ts
@@ -1,11 +1,23 @@
-import { DailyQuest } from '../entities/daily-quest.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { DailyQuest } from '../daily-quests.interpace';
 
 export class ResDailyQuestDto {
+  @ApiProperty({ example: 1 })
   readonly id: number;
+
+  @ApiProperty({ example: '제목' })
   readonly title: string;
+
+  @ApiProperty({ example: '문제 5개를 푸세요' })
   readonly content: string;
+
+  @ApiProperty({ example: 1000 })
   readonly point: number;
+
+  @ApiProperty({ example: 100 })
   readonly exp: number;
+
+  @ApiProperty({ example: 5 })
   readonly condition: number;
 
   constructor(dailyQuest: DailyQuest) {

--- a/src/daily-quests/dto/update-daily-quest.dto.ts
+++ b/src/daily-quests/dto/update-daily-quest.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateDailyQuestDto } from './create-daily-quest.dto';
+
+export class UpdateDailyQuestDto extends PartialType(CreateDailyQuestDto) {}

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -2,8 +2,8 @@ import { DailyQuestModel } from '../daily-quests.interpace';
 
 export class DailyQuest implements DailyQuestModel {
   id: number;
-  title: String;
-  content: String;
+  title: string;
+  content: string;
   point: number;
   exp: number;
   condition: number;

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -1,6 +1,6 @@
-import { DailyQuestModel } from '../daily-quests.interpace';
+import { DailyQuest } from '../daily-quests.interpace';
 
-export class DailyQuest implements DailyQuestModel {
+export class DailyQuestEntity implements DailyQuest {
   id: number;
   title: string;
   content: string;

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -1,0 +1,1 @@
+export class DailyQuest {}

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -7,4 +7,6 @@ export class DailyQuest implements DailyQuestModel {
   point: number;
   exp: number;
   condition: number;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -1,1 +1,10 @@
-export class DailyQuest {}
+import { DailyQuestModel } from '../daily-quests.interpace';
+
+export class DailyQuest implements DailyQuestModel {
+  id: number;
+  title: String;
+  content: String;
+  point: number;
+  exp: number;
+  condition: number;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#73 

## 📝작업 내용

일일퀘스트 내용을 조회 및 생성,수정,삭제 하는 api 입니다.

실제 유저가 일일퀘스트를 받고 데이터를 저장하는 api는 다음 이슈에서 작성할 예정입니다.

## 🔍 변경 사항

- [x] GET /daily-quests
- [x] GET /daily-quests/{id}
- [x] POST /daily-quests
- [x] PATCH /daily-quests/{id}
- [x] DELETE /daily-quests/{id}

## 💬리뷰 요구사항 (선택사항)
