### PR TITLE
Auth Swagger 생성

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -24,7 +24,7 @@ export class AdminController {
   ) {}
 
   // admin 로그인
-  @ApiAdmins.LoginAdmin()
+  @ApiAdmins.loginAdmin()
   @Post('login')
   @HttpCode(200)
   async loginAdmin(

--- a/src/admin/admin.swagger.ts
+++ b/src/admin/admin.swagger.ts
@@ -2,7 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export const ApiAdmins = {
-  LoginAdmin: () => {
+  loginAdmin: () => {
     return applyDecorators(
       ApiOperation({
         summary: 'admin 정보 인증',

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiExcludeEndpoint()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/src/auth/auth-swagger.ts
+++ b/src/auth/auth-swagger.ts
@@ -1,0 +1,43 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ResponseUserDto } from 'src/users/dtos/response-user.dto';
+
+export const ApiAuth = {
+  verify: () => {
+    return applyDecorators(
+      ApiCookieAuth('accessToken'),
+      ApiOperation({
+        summary: 'access 토큰 인증',
+      }),
+      ApiResponse({
+        status: 200,
+        description: `access 토큰 정보가 인증됨`,
+        type: ResponseUserDto,
+      }),
+    );
+  },
+  newAccessToken: () => {
+    return applyDecorators(
+      ApiCookieAuth('refreshToken'),
+      ApiOperation({
+        summary: 'access 토큰 재발급',
+      }),
+      ApiResponse({
+        status: 201,
+        description: `access 토큰이 재발급 됨`,
+      }),
+    );
+  },
+  logout: () => {
+    return applyDecorators(
+      ApiCookieAuth('accessToken'),
+      ApiOperation({
+        summary: '로그아웃',
+      }),
+      ApiResponse({
+        status: 204,
+        description: `로그아웃 성공`,
+      }),
+    );
+  },
+};

--- a/src/ranking/dtos/ranking-pagination-res.dto.ts
+++ b/src/ranking/dtos/ranking-pagination-res.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UserRankingsDto } from './user-rankings.dto';
+import { UserRankingDto } from './user-ranking.dto';
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
 
-export class RankingPaginationResponseDto extends OffsetPaginationBaseResponseDto<UserRankingsDto> {
+export class RankingPaginationResponseDto extends OffsetPaginationBaseResponseDto<UserRankingDto> {
   @ApiProperty({
     description: '조회된 랭킹 목록',
   })
-  readonly contents: UserRankingsDto[];
+  readonly contents: UserRankingDto[];
 
   constructor(props: Omit<RankingPaginationResponseDto, 'totalPage'>) {
     super(props);

--- a/src/ranking/dtos/ranking-query.dto.ts
+++ b/src/ranking/dtos/ranking-query.dto.ts
@@ -1,19 +1,11 @@
-import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { IsEnum, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import { Sort, SortValues } from '../entities/ranking.entity';
 import { PaginationDefaults } from 'src/common/constants/rankings-constants';
+import { RankingSortDto } from './ranking-sort.dto';
 
-export class RankingQueryDto {
-  @ApiPropertyOptional({
-    description: '랭킹 기준값 (point, level 등))',
-    example: 'point',
-    enum: SortValues,
-    default: SortValues.POINT,
-  })
-  @IsEnum(SortValues, { message: 'bad Sort value' })
-  readonly sort: Sort = SortValues.POINT; // 여기 들어가는 기본 값은 사용자가 처음 들어왔을때 보여줄 페이지
-
+export class RankingQueryDto extends RankingSortDto {
   @ApiPropertyOptional({
     description: '페이지 번호 (1부터 시작)',
     example: 1,

--- a/src/ranking/dtos/ranking-sort.dto.ts
+++ b/src/ranking/dtos/ranking-sort.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Sort, SortValues } from '../entities/ranking.entity';
+import { IsEnum } from 'class-validator';
+
+export class RankingSortDto {
+  @ApiPropertyOptional({
+    description: '랭킹 기준값 (level, point 등))',
+    example: 'level',
+    enum: SortValues,
+    default: SortValues.LEVEL,
+  })
+  @IsEnum(SortValues, { message: 'bad Sort value' })
+  readonly sort: Sort = SortValues.LEVEL; // 여기 들어가는 기본 값은 사용자가 처음 들어왔을때 보여줄 페이지
+}

--- a/src/ranking/dtos/user-ranking.dto.ts
+++ b/src/ranking/dtos/user-ranking.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UserRankingsDto {
+export class UserRankingDto {
   @ApiProperty({
     description: '사용자 ID',
     example: 22,

--- a/src/ranking/entities/ranking.entity.ts
+++ b/src/ranking/entities/ranking.entity.ts
@@ -1,7 +1,7 @@
 import { ValueOf } from 'src/common/util/type-utils';
 
 export const SortValues = {
-  POINT: 'point',
   LEVEL: 'level',
+  POINT: 'point',
 } as const;
 export type Sort = ValueOf<typeof SortValues>;

--- a/src/ranking/ranking.swagger.ts
+++ b/src/ranking/ranking.swagger.ts
@@ -16,7 +16,7 @@ export const ApiRankings = {
       }),
     );
   },
-  getMyRanking: () => {
+  findMyRanking: () => {
     return applyDecorators(
       ApiOperation({
         summary: '나의 랭킹 정보 가져오기',

--- a/src/ranking/rankings.controller.ts
+++ b/src/ranking/rankings.controller.ts
@@ -33,7 +33,7 @@ export class RankingsController {
   }
 
   // 자신의 랭킹 조회
-  @ApiRankings.getMyRanking()
+  @ApiRankings.findMyRanking()
   @Get('me/rankings')
   @UseGuards(AuthGuard('accessToken'))
   async getMyRanking(

--- a/src/ranking/rankings.module.ts
+++ b/src/ranking/rankings.module.ts
@@ -3,10 +3,11 @@ import { RankingsController } from './rankings.controller';
 import { RankingsRepository } from './rankings.repository';
 import { RankingsService } from './rankings.service';
 import { UsersCoreModule } from 'src/users/modules/users-core.module';
+import { UsersRankingsController } from './user-rankings.controller';
 
 @Module({
   imports: [UsersCoreModule],
-  controllers: [RankingsController],
+  controllers: [RankingsController, UsersRankingsController],
   providers: [RankingsService, RankingsRepository],
 })
 export class RankingsModule {}

--- a/src/ranking/rankings.repository.ts
+++ b/src/ranking/rankings.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { UserRankingsDto } from './dtos/user-rankings.dto';
+import { UserRankingDto } from './dtos/user-ranking.dto';
 
 @Injectable()
 export class RankingsRepository {
@@ -16,7 +16,7 @@ export class RankingsRepository {
     page: number,
     limit: number,
     orderBy: object,
-  ): Promise<UserRankingsDto[]> {
+  ): Promise<UserRankingDto[]> {
     const results = await this.prisma.user.findMany({
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수

--- a/src/ranking/user-rankings.controller.ts
+++ b/src/ranking/user-rankings.controller.ts
@@ -7,26 +7,26 @@ import { ApiRankings } from './ranking.swagger';
 import { RankingQueryDto } from './dtos/ranking-query.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { RankingPaginationResponseDto } from './dtos/ranking-pagination-res.dto';
+import { ResMyRankingDto } from './dtos/res-my-ranking.dto';
+import { Sort } from './entities/ranking.entity';
+import { RankingSortDto } from './dtos/ranking-sort.dto';
 
 @ApiTags('rankings')
-@Controller('rankings')
-export class RankingsController {
+@Controller('users')
+export class UsersRankingsController {
   constructor(private readonly rankingsService: RankingsService) {}
 
-  // 랭킹 페이지 조회
-  @ApiRankings.findSelectedPageRankings()
-  @Get()
-  async findSelectedPageRankings(
-    @Query() rankingsDto: RankingQueryDto,
-  ): Promise<RankingPaginationResponseDto> {
-    const { sort, page, limit } = rankingsDto;
+  // 자신의 랭킹 조회
+  @ApiRankings.findMyRanking()
+  @Get('me/rankings')
+  @UseGuards(AuthGuard('accessToken'))
+  async getMyRanking(
+    @User() user: UserInfo,
+    @Query() rankingSortDto: RankingSortDto,
+  ): Promise<ResMyRankingDto> {
+    const { sort } = rankingSortDto;
+    const myRanking = await this.rankingsService.getMyRanking(sort, user);
 
-    const allRankings = await this.rankingsService.findSelectedPageRankings(
-      sort,
-      page,
-      limit,
-    );
-
-    return allRankings;
+    return myRanking;
   }
 }

--- a/src/users/dtos/response-user.dto.ts
+++ b/src/users/dtos/response-user.dto.ts
@@ -1,27 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { User } from '@prisma/client';
 
 export class ResponseUserDto {
+  @ApiProperty({ example: 20 })
   readonly id: number;
+
+  // @ApiProperty({ example: 'google' })
   readonly provider: string;
+
+  // @ApiProperty({ example: '1067133746743816635' })
   readonly providerId: string;
+
+  @ApiProperty({ example: '이건우' })
   readonly name: string;
+
+  @ApiProperty({ example: 6 })
   readonly level: number;
+
+  @ApiProperty({ example: 128 })
   readonly experience: number;
+
+  @ApiProperty({ example: 150 })
   readonly experienceForNextLevel: number;
+
+  @ApiProperty({ example: 4800 })
   readonly point: number;
+
+  @ApiProperty({ example: '2025-01-22T02:20:18.611Z' })
   readonly createdAt: Date;
+
+  // @ApiProperty({ example: '2025-01-23T07:16:34.611Z' })
   readonly updatedAt: Date;
 
   constructor(user: User) {
     this.id = user.id;
-    this.provider = user.provider;
-    this.providerId = user.providerId;
     this.name = user.name;
     this.level = user.level;
     this.experience = user.experience;
     this.experienceForNextLevel = user.experienceForNextLevel;
     this.point = user.point;
     this.createdAt = user.createdAt;
-    this.updatedAt = user.createdAt;
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#87 

## 📝작업 내용
![image](https://github.com/user-attachments/assets/51b292ee-ebb6-4b5e-ad6a-7957defb9383)

swagger 에 auth 와 관련된 api 스웨거를 생성했습니다


## 🔍 변경 사항

- `/` 엔드포인트 Swagger 문서에서 삭제
-  `auth/google` 이나 `auth/google/callback` 같은 요청은 직접적인 요청이 아니라 문서에서 제외했습니다.
- Swagger 문서 'auth' 부분 생성

## 💬리뷰 요구사항 (선택사항)
