### PR TITLE
parts/status를 complet 로 만드는 api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN}}
+          password: ${{ secrets.GHCR_TOKEN_DG1418}}
 
       # Build 및 push
       - name: Build and push
@@ -61,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN_DG1418 }}
 
       # 앱 이미지 이름 업데이트
       - name: Update DOCKER_IMAGE in .env file

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -40,7 +40,7 @@ export class PartProgressController {
   //   await this.partProgressService.createOrUpdate(user.id, partId, body);
   // }
 
-  //@ApiPartProgress.createOrUpdate()
+  @ApiPartProgress.createOrUpdateCompleted()
   @Patch(':partId/status/completed')
   @HttpCode(204)
   @UseGuards(AuthGuard('accessToken'))

--- a/src/part-progress/part-progress.controller.ts
+++ b/src/part-progress/part-progress.controller.ts
@@ -1,14 +1,12 @@
 import {
   Controller,
   Get,
-  Body,
   Param,
   HttpCode,
   UseGuards,
   Patch,
 } from '@nestjs/common';
 import { PartProgressService } from './part-progress.service';
-import { CreatePartProgressDto } from './dto/create-part-progress.dto';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { ResPartProgressDto } from './dto/res-part-progress.dto';
 import { ApiPartProgress } from './part-progress.swagger';
@@ -30,15 +28,26 @@ export class PartProgressController {
     return ResPartProgressDto.fromArray(partProgress);
   }
 
-  @ApiPartProgress.createOrUpdate()
-  @Patch(':partId/status')
+  // @ApiPartProgress.createOrUpdate()
+  // @Patch(':partId/status')
+  // @HttpCode(204)
+  // @UseGuards(AuthGuard('accessToken'))
+  // async createOrUpdate(
+  //   @User() user: UserInfo,
+  //   @Param('partId', PositiveIntPipe) partId: number,
+  //   @Body() body: CreatePartProgressDto,
+  // ): Promise<void> {
+  //   await this.partProgressService.createOrUpdate(user.id, partId, body);
+  // }
+
+  //@ApiPartProgress.createOrUpdate()
+  @Patch(':partId/status/completed')
   @HttpCode(204)
   @UseGuards(AuthGuard('accessToken'))
-  async createOrUpdate(
+  async createOrUpdateCompleted(
     @User() user: UserInfo,
     @Param('partId', PositiveIntPipe) partId: number,
-    @Body() body: CreatePartProgressDto,
   ): Promise<void> {
-    await this.partProgressService.createOrUpdate(user.id, partId, body);
+    await this.partProgressService.createOrUpdateCompleted(user.id, partId);
   }
 }

--- a/src/part-progress/part-progress.repository.ts
+++ b/src/part-progress/part-progress.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreatePartProgressDto } from './dto/create-part-progress.dto';
 import { PartProgress } from './entities/part-progress.entity';
+import { PrismaClientOrTransaction } from 'src/prisma/prisma.type';
 
 @Injectable()
 export class PartProgressRepository {
@@ -13,12 +14,13 @@ export class PartProgressRepository {
     });
   }
 
-  async upsertPartProgress(
+  async upsertPartStatus(
     userId: number,
     partId: number,
     body: CreatePartProgressDto,
+    txOrPrisma: PrismaClientOrTransaction = this.prisma,
   ): Promise<PartProgress> {
-    return this.prisma.partProgress.upsert({
+    return txOrPrisma.partProgress.upsert({
       where: { userId_partId: { userId, partId } },
       create: { userId, partId, ...body },
       update: { userId, partId, ...body },

--- a/src/part-progress/part-progress.service.ts
+++ b/src/part-progress/part-progress.service.ts
@@ -3,7 +3,10 @@ import { CreatePartProgressDto } from './dto/create-part-progress.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { PartProgressRepository } from './part-progress.repository';
 import { PartsService } from 'src/parts/parts.service';
-import { PartProgress } from './entities/part-progress.entity';
+import {
+  PartProgress,
+  PartStatusValues,
+} from './entities/part-progress.entity';
 
 @Injectable()
 export class PartProgressService {
@@ -47,6 +50,61 @@ export class PartProgressService {
 
     await this.partsService.findOne(partId);
 
-    return this.partProgressRepository.upsertPartProgress(userId, partId, body);
+    return this.partProgressRepository.upsertPartStatus(userId, partId, body);
+  }
+
+  /**
+   * 유저의 파트진행도 상태를 COMPLETED로 만드는 메소드
+   * 다음 파트도 STARTED로 변경해줌
+   * @param userId
+   * @param partId
+   * @returns COMPLETED된 파트 리턴해줌
+   */
+  async createOrUpdateCompleted(
+    userId: number,
+    partId: number,
+  ): Promise<PartProgress> {
+    await this.findUserById(userId);
+
+    const part = await this.partsService.findOne(partId);
+
+    const sectionParts = await this.partsService.findAllBySectionId(
+      part.sectionId,
+    );
+
+    const nextOrder = part.order + 1;
+
+    const nextPart = sectionParts.find((part) => part.order === nextOrder);
+
+    const completed = new CreatePartProgressDto(PartStatusValues.COMPLETED);
+
+    //다음 순서의 파트가 없으면
+    if (!nextPart) {
+      return this.partProgressRepository.upsertPartStatus(
+        userId,
+        partId,
+        completed,
+      );
+    }
+
+    //다음 순서의 파트가 있으면
+    return this.prisma.$transaction(async (tx) => {
+      const started = new CreatePartProgressDto(PartStatusValues.STARTED);
+
+      //다음 파트의 상태는 STARTED가 됨
+      await this.partProgressRepository.upsertPartStatus(
+        userId,
+        nextPart.id,
+        started,
+        tx,
+      );
+
+      return this.partProgressRepository.upsertPartStatus(
+        userId,
+        partId,
+        completed,
+        tx,
+      );
+    });
   }
 }

--- a/src/part-progress/part-progress.swagger.ts
+++ b/src/part-progress/part-progress.swagger.ts
@@ -7,7 +7,7 @@ export const ApiPartProgress = {
   findAll: () => {
     return applyDecorators(
       ApiOperation({
-        summary: '유저의 전체 문제 풀이 현황 조회',
+        summary: '유저의 파트 status 모두 조회',
       }),
       ApiResponse({
         status: 200,
@@ -38,6 +38,19 @@ export const ApiPartProgress = {
         status: 204,
         description:
           '유저의 part-progress가 성공적으로 생성되었거나 업데이트 됨',
+      }),
+    );
+  },
+  createOrUpdateCompleted: () => {
+    return applyDecorators(
+      ApiOperation({
+        summary: '유저의 파트상태를 COMPLETED로 변경',
+        description: `같은 색션내 파트들 중에서 다음 order의 파트가 있으면 자동으로
+        STARTED로 변경함`,
+      }),
+      ApiResponse({
+        status: 204,
+        description: '유저의 파트 status가 COMPLETED로 변경됨',
       }),
     );
   },

--- a/src/part-progress/part-progress.swagger.ts
+++ b/src/part-progress/part-progress.swagger.ts
@@ -47,7 +47,7 @@ export const ApiPartProgress = {
         summary: '유저의 파트상태를 COMPLETED로 변경',
         description: `1. 유저의 파트상태를 COMPLETED로 변경함
         2. 추가로 같은 색션내 파트들 중에서 다음 order의 파트가 있으면 
-        자동으로 STARTED로 변경함`,
+        자동으로 STARTED로 변경함 3. sections API에서 users/me/sections/parts를 보면 편함`,
       }),
       ApiResponse({
         status: 204,

--- a/src/part-progress/part-progress.swagger.ts
+++ b/src/part-progress/part-progress.swagger.ts
@@ -45,8 +45,9 @@ export const ApiPartProgress = {
     return applyDecorators(
       ApiOperation({
         summary: '유저의 파트상태를 COMPLETED로 변경',
-        description: `같은 색션내 파트들 중에서 다음 order의 파트가 있으면 자동으로
-        STARTED로 변경함`,
+        description: `1. 유저의 파트상태를 COMPLETED로 변경함
+        2. 추가로 같은 색션내 파트들 중에서 다음 order의 파트가 있으면 
+        자동으로 STARTED로 변경함`,
       }),
       ApiResponse({
         status: 204,

--- a/src/parts/parts.repository.ts
+++ b/src/parts/parts.repository.ts
@@ -39,6 +39,12 @@ export class PartsRepository {
     });
   }
 
+  async findOnePartByOrder(order: number): Promise<Part | null> {
+    return this.prisma.part.findFirst({
+      where: { order },
+    });
+  }
+
   /**
    *
    * @param sectionId - 섹션 아이디 별 파트 개수를 검색

--- a/src/parts/parts.service.ts
+++ b/src/parts/parts.service.ts
@@ -109,6 +109,27 @@ export class PartsService {
     return this.partsRepository.findAllPart();
   }
 
+  /**
+   * 같은 섹션아이디의 파트들을 가져옴
+   * 만일 중복되는 order가 있으면 에러를 던짐
+   * @param sectionId
+   * @returns
+   */
+  async findAllBySectionId(sectionId: number) {
+    const parts = await this.partsRepository.findAllPartBySectionId(sectionId);
+
+    const orders = parts.map((part) => part.order);
+    const uniqueOrders = new Set(orders);
+
+    if (uniqueOrders.size !== orders.length) {
+      throw new ConflictException(
+        '같은 섹션 내에 중복된 order 값을 가진 파트가 존재합니다.',
+      );
+    }
+
+    return parts;
+  }
+
   async create(body: CreatePartDto): Promise<Part> {
     const { sectionId, name } = body;
 

--- a/src/parts/parts.swagger.ts
+++ b/src/parts/parts.swagger.ts
@@ -8,7 +8,7 @@ export const ApiParts = {
   create: () => {
     return applyDecorators(
       ApiOperation({
-        summary: 'section 생성',
+        summary: '생성',
       }),
       ApiBody({
         description: '섹션 생성에 필요한 정보',
@@ -66,7 +66,7 @@ export const ApiParts = {
   findAll: () => {
     return applyDecorators(
       ApiOperation({
-        summary: '문제파트의 종류 전체 조회',
+        summary: '모든 파트 조회',
       }),
       ApiResponse({
         status: 200,
@@ -92,7 +92,8 @@ export const ApiParts = {
   updateAll: () => {
     return applyDecorators(
       ApiOperation({
-        summary: 'part 단일 속성 수정',
+        summary: '이름 또는 섹션id 수정',
+        description: 'patch요청 이지만, 두 옵션 모두 필수로 넣어야함 ',
       }),
       ApiBody({
         description: '파트 생성에 필요한 정보',
@@ -145,7 +146,8 @@ export const ApiParts = {
   updateOrder: () => {
     return applyDecorators(
       ApiOperation({
-        summary: 'part의 순서 변경',
+        summary: '순서 변경',
+        description: '정말 필요하지 않으면 일단은 사용하지 않기... (수정예정)',
       }),
       ApiBody({
         description: '파트 수정에 필요한 order 정보',
@@ -199,7 +201,7 @@ export const ApiParts = {
   remove: () => {
     return applyDecorators(
       ApiOperation({
-        summary: '문제파트 단일 삭제',
+        summary: '삭제',
       }),
       ApiResponse({
         status: 204,


### PR DESCRIPTION
## 🔗 관련 이슈

#94 

## 📝작업 내용

**api 호출 전**

<img width="329" alt="image" src="https://github.com/user-attachments/assets/ef4c2032-cf5a-41dc-b04c-ec98a14a4af6" />

**api 호출 후**

<img width="435" alt="image" src="https://github.com/user-attachments/assets/5d259f30-06c1-4bf6-a986-f62ae6ecf442" />


위처럼 유저 파트의 status를 complet로 만들고
추가로 다음 파트를 started로 변경하는 api 입니다.




## 🔍 변경 사항

- [ ] `PATCH users/me/parts/{partId}/status/completed `작성
- [ ] 스웨거 문서 변경사항 작성
- [ ] parts 서비스에서 sectionId로 조회시 같은 order가 있는지 확인하는 로직 작성

## 💬리뷰 요구사항 (선택사항)
