### PR TITLE
locked상태의 파트를 완료하지 못하게 변경 + 파트 추가시 디폴트 상태 조건을 추가

### DIFF
--- a/src/part-progress/part-progress.module.ts
+++ b/src/part-progress/part-progress.module.ts
@@ -8,6 +8,6 @@ import { PartsModule } from 'src/parts/parts.module';
   imports: [forwardRef(() => PartsModule)],
   controllers: [PartProgressController],
   providers: [PartProgressService, PartProgressRepository],
-  exports: [PartProgressService],
+  exports: [PartProgressService, PartProgressRepository],
 })
 export class PartProgressModule {}

--- a/src/part-progress/part-progress.repository.ts
+++ b/src/part-progress/part-progress.repository.ts
@@ -20,6 +20,22 @@ export class PartProgressRepository {
     });
   }
 
+  async findOneBySectionIdAndOrderByDesc(
+    userId: number,
+    sectionId: number,
+    txOrPrisma: PrismaClientOrTransaction = this.prisma,
+  ) {
+    return txOrPrisma.partProgress.findFirst({
+      where: {
+        userId,
+        part: { sectionId },
+      },
+      orderBy: {
+        part: { order: 'desc' },
+      },
+    });
+  }
+
   async upsertPartStatus(
     userId: number,
     partId: number,

--- a/src/part-progress/part-progress.repository.ts
+++ b/src/part-progress/part-progress.repository.ts
@@ -14,6 +14,12 @@ export class PartProgressRepository {
     });
   }
 
+  async findOneByKey(userId: number, partId: number): Promise<PartProgress> {
+    return this.prisma.partProgress.findUnique({
+      where: { userId_partId: { userId, partId } },
+    });
+  }
+
   async upsertPartStatus(
     userId: number,
     partId: number,

--- a/src/parts/parts.controller.ts
+++ b/src/parts/parts.controller.ts
@@ -33,7 +33,7 @@ export class PartsController {
   @ApiParts.create()
   @Post()
   @HttpCode(204)
-  //@UseGuards(AuthGuard('adminAccessToken'))
+  @UseGuards(AuthGuard('adminAccessToken'))
   async create(@Body() createPartDto: CreatePartDto): Promise<void> {
     await this.partsService.create(createPartDto);
   }

--- a/src/parts/parts.controller.ts
+++ b/src/parts/parts.controller.ts
@@ -33,7 +33,7 @@ export class PartsController {
   @ApiParts.create()
   @Post()
   @HttpCode(204)
-  @UseGuards(AuthGuard('adminAccessToken'))
+  //@UseGuards(AuthGuard('adminAccessToken'))
   async create(@Body() createPartDto: CreatePartDto): Promise<void> {
     await this.partsService.create(createPartDto);
   }


### PR DESCRIPTION
## 🔗 관련 이슈

#97 

## 📝작업 내용

### 1. 이슈 참조 부탁드립니다.

### 2. 추가로 파트생성시 마지막 파트가 completed일때 locked로 추가되는 걸 확인했습니다.
서비스 로직을 추가해 마지막 파트가 completed이면 started로 파트상태가 추가되도록 변경했습니다.
참조 https://github.com/modern-agile-team/8term-coko-back/pull/100#discussion_r1940753929

## 🔍 변경 사항

- [x] locked때 users/me/parts/{partId}/status/completed api가 에러던짐
- [x] POST parts api 의 디폴트 상태추가 로직 수정
## 💬리뷰 요구사항 (선택사항)
