### PR TITLE
user daily quest update api 삭제 및 서버 이벤트 확인으로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/event-emitter": "^3.0.0",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/mapped-types": "^2.0.5",
         "@nestjs/passport": "^10.0.3",
@@ -1716,6 +1717,18 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.0.0.tgz",
+      "integrity": "sha512-WbvzQQ9BGnj27onh2qSLND2+4iA6Pfp4K+HLlqunB0Uz0614O8lGMtcveSss2IOxsox8EhSI54WAvuAsDrX1hA==",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -4379,6 +4392,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^3.0.0",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/mapped-types": "^2.0.5",
     "@nestjs/passport": "^10.0.3",

--- a/prisma/migrations/20250212021729_update_daily_quest/migration.sql
+++ b/prisma/migrations/20250212021729_update_daily_quest/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `exp` on the `daily_quests` table. All the data in the column will be lost.
+  - You are about to drop the column `title` on the `daily_quests` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "daily_quests" DROP COLUMN "exp",
+DROP COLUMN "title",
+ADD COLUMN     "experience" INTEGER NOT NULL DEFAULT 0,
+ALTER COLUMN "point" SET DEFAULT 0,
+ALTER COLUMN "condition" SET DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,11 +202,10 @@ model AdminUser {
 
 model DailyQuest {
   id             Int              @id @default(autoincrement())
-  title          String           @db.VarChar(50)
   content        String           @db.VarChar(255)
-  point          Int
-  exp            Int
-  condition      Int
+  point          Int              @default(0)
+  experience     Int              @default(0)
+  condition      Int              @default(0)
   createdAt      DateTime         @default(now()) @map("created_at")
   updatedAt      DateTime         @updatedAt @map("updated_at")
   UserDailyQuest UserDailyQuest[]

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { PaginationModule } from './pagination/pagination.module';
 import { DailyQuestsModule } from './daily-quests/daily-quests.module';
 import { RankingsModule } from './ranking/rankings.module';
 import { AttendanceModule } from './attendance/attendance.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { AttendanceModule } from './attendance/attendance.module';
     PaginationModule,
     DailyQuestsModule,
     AttendanceModule,
+    EventEmitterModule.forRoot(),
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/daily-quests/daily-quests.interface.ts
+++ b/src/daily-quests/daily-quests.interface.ts
@@ -1,9 +1,8 @@
 export interface DailyQuest {
   id: number;
-  title: string;
   content: string;
   point: number;
-  exp: number;
+  experience: number;
   condition: number;
   createdAt: Date;
   updatedAt: Date;

--- a/src/daily-quests/dto/create-daily-quest.dto.ts
+++ b/src/daily-quests/dto/create-daily-quest.dto.ts
@@ -1,14 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, Min } from 'class-validator';
+import { DailyQuest } from '../daily-quests.interface';
 
-export class CreateDailyQuestDto {
-  @ApiProperty({
-    description: '제목',
-    example: '제목',
-  })
-  @IsString()
-  readonly title: string;
-
+export class CreateDailyQuestDto
+  implements Omit<DailyQuest, 'id' | 'createdAt' | 'updatedAt'>
+{
   @ApiProperty({
     description: '내용',
     example: '문제 5개를 푸세요',
@@ -30,7 +26,7 @@ export class CreateDailyQuestDto {
   })
   @IsInt()
   @Min(0)
-  readonly exp: number;
+  readonly experience: number;
 
   @ApiProperty({
     description: '달성조건',

--- a/src/daily-quests/dto/res-daily-quest.dto.ts
+++ b/src/daily-quests/dto/res-daily-quest.dto.ts
@@ -1,12 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { DailyQuest } from '../daily-quests.interface';
 
-export class ResDailyQuestDto {
+export class ResDailyQuestDto
+  implements Omit<DailyQuest, 'createdAt' | 'updatedAt'>
+{
   @ApiProperty({ example: 1 })
   readonly id: number;
-
-  @ApiProperty({ example: '제목' })
-  readonly title: string;
 
   @ApiProperty({ example: '문제 5개를 푸세요' })
   readonly content: string;
@@ -15,17 +14,16 @@ export class ResDailyQuestDto {
   readonly point: number;
 
   @ApiProperty({ example: 100 })
-  readonly exp: number;
+  readonly experience: number;
 
   @ApiProperty({ example: 5 })
   readonly condition: number;
 
   constructor(dailyQuest: DailyQuest) {
     this.id = dailyQuest.id;
-    this.title = dailyQuest.title;
     this.content = dailyQuest.content;
     this.point = dailyQuest.point;
-    this.exp = dailyQuest.exp;
+    this.experience = dailyQuest.experience;
     this.condition = dailyQuest.condition;
   }
 

--- a/src/daily-quests/entities/daily-quest.entity.ts
+++ b/src/daily-quests/entities/daily-quest.entity.ts
@@ -5,7 +5,7 @@ export class DailyQuestEntity implements DailyQuest {
   title: string;
   content: string;
   point: number;
-  exp: number;
+  experience: number;
   condition: number;
   createdAt: Date;
   updatedAt: Date;

--- a/src/daily-quests/users-daily-quests/dto/res-user-daily-quest.dto.ts
+++ b/src/daily-quests/users-daily-quests/dto/res-user-daily-quest.dto.ts
@@ -1,8 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ResDailyQuestDto } from 'src/daily-quests/dto/res-daily-quest.dto';
-import { UserDailyQuestWiteQuestInfo } from '../users-daily-quests.interface';
+import {
+  UserDailyQuest,
+  UserDailyQuestWiteQuestInfo,
+} from '../users-daily-quests.interface';
 
-export class ResUserDailyQuestDto {
+export class ResUserDailyQuestDto
+  implements Omit<UserDailyQuest, 'createdAt' | 'updatedAt'>
+{
   @ApiProperty({ example: 1 })
   readonly id: number;
 

--- a/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
+++ b/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, Max, Min } from 'class-validator';
+import { UserDailyQuest } from '../users-daily-quests.interface';
 
 export class UpdateUsersDailyQuestDto {
   @ApiProperty({

--- a/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
+++ b/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, Max, Min } from 'class-validator';
-import { UserDailyQuest } from '../users-daily-quests.interface';
 
 export class UpdateUsersDailyQuestDto {
   @ApiProperty({

--- a/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
+++ b/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
@@ -10,4 +10,8 @@ export class UpdateUsersDailyQuestDto {
   @Min(0)
   @Max(1000)
   readonly conditionProgress: number;
+
+  constructor(conditionProgress: number) {
+    this.conditionProgress = conditionProgress;
+  }
 }

--- a/src/daily-quests/users-daily-quests/users-daily-quests.controller.ts
+++ b/src/daily-quests/users-daily-quests/users-daily-quests.controller.ts
@@ -24,17 +24,17 @@ export class UsersDailyQuestsController {
     return ResUserDailyQuestDto.fromArray(userDailyQuests);
   }
 
-  @Patch(':userDailyQuestId')
-  @ApiUserDailyQuest.update()
-  @UseGuards(AuthGuard('accessToken'))
-  async update(
-    @Param('userDailyQuestId', PositiveIntPipe) userDailyQuestId: number,
-    @Body() body: UpdateUsersDailyQuestDto,
-  ): Promise<ResUserDailyQuestDto> {
-    const userDailyQuest = await this.usersDailyQuestsService.update(
-      userDailyQuestId,
-      body,
-    );
-    return new ResUserDailyQuestDto(userDailyQuest);
-  }
+  // @Patch(':userDailyQuestId')
+  // @ApiUserDailyQuest.update()
+  // @UseGuards(AuthGuard('accessToken'))
+  // async update(
+  //   @Param('userDailyQuestId', PositiveIntPipe) userDailyQuestId: number,
+  //   @Body() body: UpdateUsersDailyQuestDto,
+  // ): Promise<ResUserDailyQuestDto> {
+  //   const userDailyQuest = await this.usersDailyQuestsService.update(
+  //     userDailyQuestId,
+  //     body,
+  //   );
+  //   return new ResUserDailyQuestDto(userDailyQuest);
+  // }
 }

--- a/src/daily-quests/users-daily-quests/users-daily-quests.module.ts
+++ b/src/daily-quests/users-daily-quests/users-daily-quests.module.ts
@@ -4,9 +4,14 @@ import { UsersDailyQuestsController } from './users-daily-quests.controller';
 import { UsersDailyQuestsRepository } from './users-daily-quests.repository';
 import { DailyQuestsModule } from '../daily-quests.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ProgressModule } from 'src/progress/progress.module';
 
 @Module({
-  imports: [forwardRef(() => DailyQuestsModule), ScheduleModule.forRoot()],
+  imports: [
+    forwardRef(() => DailyQuestsModule),
+    ScheduleModule.forRoot(),
+    ProgressModule,
+  ],
   controllers: [UsersDailyQuestsController],
   providers: [UsersDailyQuestsService, UsersDailyQuestsRepository],
 })

--- a/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
+++ b/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
@@ -8,13 +8,18 @@ import {
   UserDailyQuestWiteQuestInfo,
 } from './users-daily-quests.interface';
 import { DAILY_RESET } from './const/users-daily-quests.const';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Progress } from 'src/progress/entities/progress.entity';
+import { ProgressRepository } from 'src/progress/progress.repository';
 
 @Injectable()
 export class UsersDailyQuestsService {
   constructor(
+    private readonly progressRepository: ProgressRepository,
     private readonly dailyQuestsRepository: DailyQuestsRepository,
     private readonly usersDailyQuestsRepository: UsersDailyQuestsRepository,
   ) {}
+
   async findOne(userDailyQuestId: number): Promise<UserDailyQuest> {
     const userDailyQuest =
       await this.usersDailyQuestsRepository.findOneById(userDailyQuestId);
@@ -36,8 +41,8 @@ export class UsersDailyQuestsService {
       return usersDailyQuests;
     }
 
-    const newUsersDailyQuests = await this.createRandomUserDailyQuest(userId);
-    return [newUsersDailyQuests];
+    const newUserDailyQuest = await this.createRandomUserDailyQuest(userId);
+    return [newUserDailyQuest];
   }
 
   async createRandomUserDailyQuest(
@@ -58,32 +63,38 @@ export class UsersDailyQuestsService {
     return this.usersDailyQuestsRepository.create(userId, id);
   }
 
-  async update(
-    userDailyQuestId: number,
-    body: UpdateUsersDailyQuestDto,
-  ): Promise<UserDailyQuestWiteQuestInfo> {
-    const { conditionProgress } = body;
-    const { dailyQuestId } = await this.findOne(userDailyQuestId);
-    const dailyQuest = await this.dailyQuestsRepository.findOne(dailyQuestId);
+  async update(userId: number): Promise<UserDailyQuestWiteQuestInfo | null> {
+    const [userDailyQuest] = await this.findAll(userId);
 
-    const updateByCompleted = (completed: boolean) => {
-      const newBody = { ...body, completed };
+    if (!userDailyQuest) return null;
 
-      return this.usersDailyQuestsRepository.updateById(
-        userDailyQuestId,
-        newBody,
-      );
-    };
+    // 완료된 퀘스트는 업데이트하지 않음
+    if (userDailyQuest.completed) return null;
 
-    if (dailyQuest.condition <= conditionProgress) {
-      return updateByCompleted(true);
-    }
+    const today = new Date();
+    const isCorrectTrueCount =
+      await this.progressRepository.countProgressByUserIdAndDate(userId, today);
 
-    return updateByCompleted(false);
+    const updateDto = new UpdateUsersDailyQuestDto(isCorrectTrueCount);
+
+    const shouldBeCompleted =
+      userDailyQuest.dailyQuest.condition <= updateDto.conditionProgress;
+
+    const updatedData = { ...updateDto, completed: shouldBeCompleted };
+
+    return this.usersDailyQuestsRepository.updateById(
+      userDailyQuest.id,
+      updatedData,
+    );
   }
 
   @Cron(DAILY_RESET)
   async deleteAllDailyQuests(): Promise<{ count: number }> {
     return this.usersDailyQuestsRepository.deleteAll();
+  }
+
+  @OnEvent('progress.updated')
+  async handleProgressUpdatedEvent(progress: Progress) {
+    await this.update(progress.userId);
   }
 }

--- a/src/progress/progress.repository.ts
+++ b/src/progress/progress.repository.ts
@@ -8,6 +8,28 @@ import { Progress } from './entities/progress.entity';
 export class ProgressRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async countProgressByUserIdAndDate(
+    userId: number,
+    targetDate: Date,
+  ): Promise<number> {
+    const startOfDay = new Date(targetDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(targetDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    return this.prisma.progress.count({
+      where: {
+        userId,
+        isCorrect: true,
+        updatedAt: {
+          gte: startOfDay,
+          lt: endOfDay,
+        },
+      },
+    });
+  }
+
   async countProgressByQuery(
     userId: number,
     query: QueryProgressDto,


### PR DESCRIPTION
## 🔗 관련 이슈

#120 

## 📝작업 내용

![image](https://github.com/user-attachments/assets/0e1ca541-5164-4beb-9fee-299d4f5883c0)

**1. api 한개 삭제 되었습니다. 이제 클라이언트에서 일일퀘스트 수정을 요청하지 않고 서버에서 관리합니다.
2. progress create 또는 update 시 유저 일일 퀘스트를 update 합니다.
3. nestjs event-emitter를 사용해 이벤트 발생과, 이벤트시 실행을 구현했습니다.**

event-emitter를 사용한 이유는 progress 모듈에 usersDailyQuest 모듈을 의존성주입하기 싫어서 입니다.
지금까지 왜 잘 했는데 갑자기 그러냐?! 라고 물어보시면; 대단한 이유는 없습니다 😅

usersDailyQuest를 업데이트하는 순간이 기존 "patch 요청을 클라이언트가 보낼때" 라는 이벤트에서
"progress 업데이트시" 라는 이벤트로 변경되면서

새로운 우리의 비즈니스 로직 변경이 progress 모듈의 수정으로 이어지는게 생각보다 싫었습니다...

기존 이벤트 기반 에러처리를 https://github.com/honey-moa/honey-moa-server 허니모아에서 보면서
저희 메서드 실행도 이렇게 해보면 간단하지 않을까 하면서 작성했습니다.

참조 : https://docs.nestjs.com/techniques/events

생각보다 깊게 참조하지 않아서 지적할 사항이 많을거 같습니다. 😅

## 🔍 변경 사항

- [x] nestjs event-emitte 설치
- [x] progress 서비스에서 이벤트 발생
- [x] usersDailyQuest 서비스 로직 변경

## 💬리뷰 요구사항 (선택사항)

- 더 좋은 이벤트 처리에 대해서 공부 더 해보고 리팩 이어나가겠습니다.