### PR TITLE
유저의 일일퀘스트 진행도가 일일퀘스트 목표치를 상회 하던 에러 수정

### DIFF
--- a/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
+++ b/src/daily-quests/users-daily-quests/dto/update-users-daily-quest.dto.ts
@@ -11,6 +11,12 @@ export class UpdateUsersDailyQuestDto {
   @Max(1000)
   readonly conditionProgress: number;
 
+  @ApiProperty({
+    description: '완료 유뮤',
+    example: false,
+  })
+  readonly completed: boolean;
+
   constructor(conditionProgress: number) {
     this.conditionProgress = conditionProgress;
   }

--- a/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
+++ b/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
@@ -75,12 +75,17 @@ export class UsersDailyQuestsService {
     const isCorrectTrueCount =
       await this.progressRepository.countProgressByUserIdAndDate(userId, today);
 
-    const updateDto = new UpdateUsersDailyQuestDto(isCorrectTrueCount);
-
     const shouldBeCompleted =
-      userDailyQuest.dailyQuest.condition <= updateDto.conditionProgress;
+      userDailyQuest.dailyQuest.condition <= isCorrectTrueCount;
 
-    const updatedData = { ...updateDto, completed: shouldBeCompleted };
+    const conditionProgress = shouldBeCompleted
+      ? userDailyQuest.dailyQuest.condition
+      : isCorrectTrueCount;
+
+    const updatedData: UpdateUsersDailyQuestDto = {
+      conditionProgress,
+      completed: shouldBeCompleted,
+    };
 
     return this.usersDailyQuestsRepository.updateById(
       userDailyQuest.id,


### PR DESCRIPTION
## 🔗 관련 이슈

#127 

## 📝작업 내용

![image](https://github.com/user-attachments/assets/83b95a18-42f3-4ac9-9870-7c673ac26837)
erd 내용처럼 

유저의 일일퀘스트 진행도 `(conditionProgress)`가 있습니다.
이 값은 `progress`에서 오늘자 문제를 맞춘 데이터를 조회해 카운트 값을 가져와 저장됩니다.

오늘 12문제를 맞추면 목표`(condition)`가 10 이여도

`목표 : 12/10`

처럼 진행도가 목표를 상회하는 에러가 있었습니다.

해당서비스 로직을 변경해 이 에러를 수정합니다.

## 🔍 변경 사항

- [x] 유저일일퀘스트 서비스클래스의 업데이트 메서드 로직 수정

## 💬리뷰 요구사항 (선택사항)
