### PR TITLE
레벨클리어 도전과제 세부로직 작성

### DIFF
--- a/src/challenges/challenges.interface.ts
+++ b/src/challenges/challenges.interface.ts
@@ -1,5 +1,5 @@
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
-import { ChallengeType } from './const/challenges.constant';
+import { ChallengeType } from './user-challenges/user-challenges.interface';
 
 export interface Challenge {
   id: number;

--- a/src/challenges/challenges.module.ts
+++ b/src/challenges/challenges.module.ts
@@ -8,6 +8,7 @@ import { SectionsChallengesService } from './section-clear-challenges.service';
 import { ChallengesEventsListener } from './events/challenges.event';
 import { SectionsModule } from 'src/sections/sections.module';
 import { SseModule } from 'src/sse/sse.module';
+import { LevelClearChallengesService } from './level-clear-challenges.service';
 
 @Module({
   imports: [UserChallengesModule, UsersCoreModule, SectionsModule, SseModule],
@@ -16,6 +17,7 @@ import { SseModule } from 'src/sse/sse.module';
     ChallengesService,
     ChallengesRepository,
     SectionsChallengesService,
+    LevelClearChallengesService,
 
     ChallengesEventsListener,
   ],

--- a/src/challenges/challenges.repository.ts
+++ b/src/challenges/challenges.repository.ts
@@ -4,7 +4,7 @@ import { UpdateChallengesDto } from './dto/update-challenges.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 import { Challenge } from './challenges.interface';
-import { ChallengeType } from './const/challenges.constant';
+import { ChallengeType } from './user-challenges/user-challenges.interface';
 
 @Injectable()
 export class ChallengesRepository {

--- a/src/challenges/challenges.repository.ts
+++ b/src/challenges/challenges.repository.ts
@@ -45,6 +45,15 @@ export class ChallengesRepository {
     });
   }
 
+  async findManyByTypeAndConditions(
+    challengeType: ChallengeType,
+    conditions: number[],
+  ): Promise<Challenge[]> {
+    return await this.prisma.challenge.findMany({
+      where: { challengeType, condition: { in: conditions } },
+    });
+  }
+
   async createChallenge(
     body: CreateChallengesDto,
     defaultUserChallenges: { userId: number }[],

--- a/src/challenges/const/challenges.constant.ts
+++ b/src/challenges/const/challenges.constant.ts
@@ -20,5 +20,3 @@ export const EVENT = {
     LEVEL_UP: 'user.levelUp',
   },
 } as const;
-
-event;

--- a/src/challenges/const/challenges.constant.ts
+++ b/src/challenges/const/challenges.constant.ts
@@ -1,5 +1,3 @@
-import { ValueOf } from 'src/common/util/type-utils';
-
 /**
  * 도전과제 타입 값들
  */
@@ -14,4 +12,11 @@ export const ChallengeTypeValues = {
   FIRST_404_VISIT: 'FIRST_404_VISIT',
 } as const;
 
-export type ChallengeType = ValueOf<typeof ChallengeTypeValues>;
+export const Evnet = {
+  PartStatus: {
+    Completed: 'partStatus.completed',
+  },
+  User: {
+    LevelUp: 'user.levelUp',
+  },
+} as const;

--- a/src/challenges/const/challenges.constant.ts
+++ b/src/challenges/const/challenges.constant.ts
@@ -12,11 +12,13 @@ export const ChallengeTypeValues = {
   FIRST_404_VISIT: 'FIRST_404_VISIT',
 } as const;
 
-export const Evnet = {
-  PartStatus: {
-    Completed: 'partStatus.completed',
+export const EVENT = {
+  PART_STATUS: {
+    COMPLETED: 'partStatus.completed',
   },
-  User: {
-    LevelUp: 'user.levelUp',
+  USER: {
+    LEVEL_UP: 'user.levelUp',
   },
 } as const;
+
+event;

--- a/src/challenges/dto/create-challenges.dto.ts
+++ b/src/challenges/dto/create-challenges.dto.ts
@@ -1,10 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsInt, IsString, Max, Min } from 'class-validator';
 import { Challenge } from '../challenges.interface';
-import {
-  ChallengeType,
-  ChallengeTypeValues,
-} from '../const/challenges.constant';
+import { ChallengeTypeValues } from '../const/challenges.constant';
+import { ChallengeType } from '../user-challenges/user-challenges.interface';
 
 export class CreateChallengesDto
   implements Omit<Challenge, 'id' | 'createdAt' | 'updatedAt'>

--- a/src/challenges/dto/res-challenges.dto.ts
+++ b/src/challenges/dto/res-challenges.dto.ts
@@ -1,9 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Challenge } from '../challenges.interface';
-import {
-  ChallengeType,
-  ChallengeTypeValues,
-} from '../const/challenges.constant';
+import { ChallengeTypeValues } from '../const/challenges.constant';
+import { ChallengeType } from '../user-challenges/user-challenges.interface';
 
 export class ResChallengesDto
   implements Omit<Challenge, 'createdAt' | 'updatedAt'>

--- a/src/challenges/events/challenges.event.ts
+++ b/src/challenges/events/challenges.event.ts
@@ -4,7 +4,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { SseService } from 'src/sse/sse.service';
 import { LevelClearChallengesService } from '../level-clear-challenges.service';
 import { UserInfo } from 'src/users/entities/user.entity';
-import { Evnet } from '../const/challenges.constant';
+import { EVENT } from '../const/challenges.constant';
 
 @Injectable()
 export class ChallengesEventsListener {
@@ -17,7 +17,7 @@ export class ChallengesEventsListener {
   /**
    * partStatus가 completed로 변경될 때 호출되는 이벤트 (섹션 도전과제 처리)
    */
-  @OnEvent(Evnet.PartStatus.Completed)
+  @OnEvent(EVENT.PART_STATUS.COMPLETED)
   async handleSectionsChallenge(payload: {
     userId: number;
     sectionId: number;
@@ -33,7 +33,7 @@ export class ChallengesEventsListener {
       if (userChallengesAndInfo) {
         // SSE 메시지 전송
         this.sseService.notifyUser(userId, {
-          type: Evnet.PartStatus.Completed,
+          type: EVENT.PART_STATUS.COMPLETED,
           message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
           timestamp: new Date().toISOString(),
         });
@@ -49,7 +49,7 @@ export class ChallengesEventsListener {
   /**
    * 유저가 레벨 10업 했을 때 호출되는 이벤트 (레벨 도전과제 처리)
    */
-  @OnEvent(Evnet.User.LevelUp)
+  @OnEvent(EVENT.USER.LEVEL_UP)
   async handleLevelChallenge(payload: { user: UserInfo }) {
     const { user } = payload;
     try {
@@ -59,7 +59,7 @@ export class ChallengesEventsListener {
       if (userChallengesAndInfo) {
         // SSE 메시지 전송
         this.sseService.notifyUser(user.id, {
-          type: Evnet.User.LevelUp,
+          type: EVENT.USER.LEVEL_UP,
           message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
           timestamp: new Date().toISOString(),
         });

--- a/src/challenges/events/challenges.event.ts
+++ b/src/challenges/events/challenges.event.ts
@@ -2,18 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { SectionsChallengesService } from '../section-clear-challenges.service';
 import { OnEvent } from '@nestjs/event-emitter';
 import { SseService } from 'src/sse/sse.service';
+import { LevelClearChallengesService } from '../level-clear-challenges.service';
+import { UserInfo } from 'src/users/entities/user.entity';
 
 @Injectable()
 export class ChallengesEventsListener {
   constructor(
     private readonly sseService: SseService,
     private readonly sectionsChallengesService: SectionsChallengesService,
+    private readonly levelClearChallengesService: LevelClearChallengesService,
   ) {}
 
   /**
-   * partStatus가 completed로 변경될 때, 호출되는 이벤트
-   * 전체 섹션이 완료되었는지 체크함
-   * @param payload
+   * 유저가 레벨 10업 했을 때 마다 호출되는 이벤트
    */
   @OnEvent('partStatus.completed')
   async handleSectionsChallenge(payload: {
@@ -23,7 +24,7 @@ export class ChallengesEventsListener {
     const { userId, sectionId } = payload;
 
     const userChallengesAndInfo =
-      await this.sectionsChallengesService.chackedByAllPartStatusCompleted(
+      await this.sectionsChallengesService.checkAndCompleteSectionChallenge(
         userId,
         sectionId,
       );
@@ -32,6 +33,34 @@ export class ChallengesEventsListener {
       //sse메시지
       this.sseService.notifyUser(userId, {
         type: 'partStatus.completed',
+        message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  /**
+   * partStatus가 completed로 변경될 때, 호출되는 이벤트
+   * 전체 섹션이 완료되었는지 체크함
+   * @param payload
+   */
+  @OnEvent('user.level10Up')
+  async handleLevelChallenge(payload: {
+    userId: number;
+    completedLevel: number;
+  }) {
+    const { userId, completedLevel } = payload;
+
+    const userChallengesAndInfo =
+      await this.levelClearChallengesService.chackedByUserLevel(
+        userId,
+        completedLevel,
+      );
+
+    if (userChallengesAndInfo) {
+      //sse메시지
+      this.sseService.notifyUser(userId, {
+        type: 'user.level10Up',
         message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
         timestamp: new Date().toISOString(),
       });

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -19,6 +19,7 @@ export class LevelClearChallengesService {
       completedLevel,
     );
     if (!challenge) {
+      return null;
       throw new NotFoundException('해당 레벨 도전과제가 존재하지 않습니다.');
     }
 
@@ -28,7 +29,8 @@ export class LevelClearChallengesService {
         userId,
         challenge.id,
       );
-    if (userChallenge) {
+    if (!userChallenge) {
+      return null;
       throw new NotFoundException('유저에게 도전과제가 없습니다.');
     }
     if (userChallenge.completed) {

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -20,7 +20,6 @@ export class LevelClearChallengesService {
     );
     if (!challenge) {
       return null;
-      throw new NotFoundException('해당 레벨 도전과제가 존재하지 않습니다.');
     }
 
     // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
@@ -30,7 +29,6 @@ export class LevelClearChallengesService {
         challenge.id,
       );
     if (!userChallenge) {
-      return null;
       throw new NotFoundException('유저에게 도전과제가 없습니다.');
     }
     if (userChallenge.completed) {

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -26,10 +26,10 @@ export class LevelClearChallengesService {
       (userChallenge) => userChallenge.id,
     );
 
-    await this.userChallengesRepository.updateManyByUserAndType(
-      userChallengeIds,
-      { completed: true, completedDate: new Date() },
-    );
+    await this.userChallengesRepository.updateManyByIds(userChallengeIds, {
+      completed: true,
+      completedDate: new Date(),
+    });
 
     const [first, ...order] = userChallenges;
 

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { ChallengesRepository } from './challenges.repository';
 import { UserChallengesRepository } from './user-challenges/user-challenges.repository';
 import { ChallengeTypeValues } from './const/challenges.constant';
 import { UserInfo } from 'src/users/entities/user.entity';
@@ -10,7 +9,6 @@ export class LevelClearChallengesService {
   private readonly challengeType = ChallengeTypeValues.LEVEL_CLEAR;
 
   constructor(
-    private readonly challengesRepository: ChallengesRepository,
     private readonly userChallengesRepository: UserChallengesRepository,
   ) {}
 

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -4,53 +4,84 @@ import { UserChallengesRepository } from './user-challenges/user-challenges.repo
 import { UpdateUserChallengesDto } from './user-challenges/dto/update-user-challenges.dto';
 import { ChallengeTypeValues } from './const/challenges.constant';
 import { UserInfo } from 'src/users/entities/user.entity';
-import { UsersRepository } from 'src/users/repositories/users.reposirory';
 
 @Injectable()
 export class LevelClearChallengesService {
   private readonly challengeType = ChallengeTypeValues.LEVEL_CLEAR;
 
   constructor(
-    private readonly usersRepository: UsersRepository,
     private readonly challengesRepository: ChallengesRepository,
     private readonly userChallengesRepository: UserChallengesRepository,
   ) {}
 
-  async chackedByUserLevel(userId: number, completedLevel: number) {
-    //const userId = user.id;
-    //const completedLevel = level || user.level; // 이걸 잘 사용해봐도 좋을거 같음
+  /**
+   * 유저의 현재 레벨에 해당하는 모든 milestone(예: 10, 20, 30 등)에 대해
+   * 도전과제를 한 번에 처리하는 메서드입니다.
+   */
+  async completeAllChallengesForUser(user: UserInfo) {
+    //목표값 구하기
+    const milestones = this.getMilestones(user.level, 10);
 
-    const challenge = await this.challengesRepository.findOneByTypeAndCondition(
-      this.challengeType,
-      completedLevel,
-    );
-    if (!challenge) {
+    //목표값이 없으면 null
+    if (milestones.length === 0) {
       return null;
     }
 
-    // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
-    const userChallenge =
-      await this.userChallengesRepository.findOneByChallenge(
-        userId,
-        challenge.id,
+    // 목표에 해당하는 도전과제들을 조회
+    const challenges =
+      await this.challengesRepository.findManyByTypeAndConditions(
+        this.challengeType,
+        milestones,
       );
-    if (!userChallenge) {
-      throw new NotFoundException('유저에게 도전과제가 없습니다.');
-    }
-    if (userChallenge.completed) {
+    if (challenges.length === 0) {
       return null;
     }
 
-    //없으면 완료 처리
+    const challengeIds = challenges.map((challenge) => challenge.id);
+
+    // 유저의 도전과제 상태들을 조회
+    const userChallenges =
+      await this.userChallengesRepository.findManyByUserAndChallengeIds(
+        user.id,
+        challengeIds,
+      );
+
+    if (challenges.length !== userChallenges.length) {
+      throw new NotFoundException(
+        '도전과제에 대한 유저의 도전과제 목록이 부족합니다.',
+      );
+    }
+
     const updateData: UpdateUserChallengesDto = {
       completed: true,
       completedDate: new Date(),
     };
 
-    return this.userChallengesRepository.updateUserChallengesByUserId(
-      userId,
-      challenge.id,
+    return await this.userChallengesRepository.updateManyUserChallenges(
+      user.id,
+      challengeIds,
       updateData,
     );
+  }
+
+  /**
+   * 주어진 레벨과 간격을 기반으로 달성 가능한 milestone 목록을 반환합니다.
+   * 예를 들어, 레벨이 32이고 간격이 10이면 [10, 20, 30]을 반환합니다.
+   *
+   * @param level 유저의 현재 레벨
+   * @param interval milestone 간격 (기본값: 10)
+   * @returns milestone 배열
+   */
+  private getMilestones(level: number, interval: number = 10): number[] {
+    const milestones: number[] = [];
+    const maxMilestone = Math.floor(level / interval) * interval;
+    for (
+      let milestone = interval;
+      milestone <= maxMilestone;
+      milestone += interval
+    ) {
+      milestones.push(milestone);
+    }
+    return milestones;
   }
 }

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ChallengesRepository } from './challenges.repository';
 import { UserChallengesRepository } from './user-challenges/user-challenges.repository';
-import { UpdateUserChallengesDto } from './user-challenges/dto/update-user-challenges.dto';
 import { ChallengeTypeValues } from './const/challenges.constant';
 import { UserInfo } from 'src/users/entities/user.entity';
+import { UserChallengesAndInfo } from './user-challenges/user-challenges.interface';
 
 @Injectable()
 export class LevelClearChallengesService {
@@ -14,74 +14,27 @@ export class LevelClearChallengesService {
     private readonly userChallengesRepository: UserChallengesRepository,
   ) {}
 
-  /**
-   * 유저의 현재 레벨에 해당하는 모든 milestone(예: 10, 20, 30 등)에 대해
-   * 도전과제를 한 번에 처리하는 메서드입니다.
-   */
-  async completeAllChallengesForUser(user: UserInfo) {
-    //목표값 구하기
-    const milestones = this.getMilestones(user.level, 10);
-
-    //목표값이 없으면 null
-    if (milestones.length === 0) {
-      return null;
-    }
-
-    // 목표에 해당하는 도전과제들을 조회
-    const challenges =
-      await this.challengesRepository.findManyByTypeAndConditions(
-        this.challengeType,
-        milestones,
-      );
-    if (challenges.length === 0) {
-      return null;
-    }
-
-    const challengeIds = challenges.map((challenge) => challenge.id);
-
-    // 유저의 도전과제 상태들을 조회
+  async completedChallenge(
+    user: UserInfo,
+  ): Promise<UserChallengesAndInfo | null> {
     const userChallenges =
-      await this.userChallengesRepository.findManyByUserAndChallengeIds(
+      await this.userChallengesRepository.findManyByUserAndType(
         user.id,
-        challengeIds,
+        user.level,
+        this.challengeType,
       );
 
-    if (challenges.length !== userChallenges.length) {
-      throw new NotFoundException(
-        '도전과제에 대한 유저의 도전과제 목록이 부족합니다.',
-      );
-    }
-
-    const updateData: UpdateUserChallengesDto = {
-      completed: true,
-      completedDate: new Date(),
-    };
-
-    return await this.userChallengesRepository.updateManyUserChallenges(
-      user.id,
-      challengeIds,
-      updateData,
+    const userChallengeIds = userChallenges.map(
+      (userChallenge) => userChallenge.id,
     );
-  }
 
-  /**
-   * 주어진 레벨과 간격을 기반으로 달성 가능한 milestone 목록을 반환합니다.
-   * 예를 들어, 레벨이 32이고 간격이 10이면 [10, 20, 30]을 반환합니다.
-   *
-   * @param level 유저의 현재 레벨
-   * @param interval milestone 간격 (기본값: 10)
-   * @returns milestone 배열
-   */
-  private getMilestones(level: number, interval: number = 10): number[] {
-    const milestones: number[] = [];
-    const maxMilestone = Math.floor(level / interval) * interval;
-    for (
-      let milestone = interval;
-      milestone <= maxMilestone;
-      milestone += interval
-    ) {
-      milestones.push(milestone);
-    }
-    return milestones;
+    await this.userChallengesRepository.updateManyByUserAndType(
+      userChallengeIds,
+      { completed: true, completedDate: new Date() },
+    );
+
+    const [first, ...order] = userChallenges;
+
+    return first;
   }
 }

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -3,17 +3,23 @@ import { ChallengesRepository } from './challenges.repository';
 import { UserChallengesRepository } from './user-challenges/user-challenges.repository';
 import { UpdateUserChallengesDto } from './user-challenges/dto/update-user-challenges.dto';
 import { ChallengeTypeValues } from './const/challenges.constant';
+import { UserInfo } from 'src/users/entities/user.entity';
+import { UsersRepository } from 'src/users/repositories/users.reposirory';
 
 @Injectable()
 export class LevelClearChallengesService {
   private readonly challengeType = ChallengeTypeValues.LEVEL_CLEAR;
 
   constructor(
+    private readonly usersRepository: UsersRepository,
     private readonly challengesRepository: ChallengesRepository,
     private readonly userChallengesRepository: UserChallengesRepository,
   ) {}
 
   async chackedByUserLevel(userId: number, completedLevel: number) {
+    //const userId = user.id;
+    //const completedLevel = level || user.level; // 이걸 잘 사용해봐도 좋을거 같음
+
     const challenge = await this.challengesRepository.findOneByTypeAndCondition(
       this.challengeType,
       completedLevel,

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ChallengesRepository } from './challenges.repository';
+import { UserChallengesRepository } from './user-challenges/user-challenges.repository';
+import { UpdateUserChallengesDto } from './user-challenges/dto/update-user-challenges.dto';
+import { ChallengeTypeValues } from './const/challenges.constant';
+
+@Injectable()
+export class LevelClearChallengesService {
+  private readonly challengeType = ChallengeTypeValues.LEVEL_CLEAR;
+
+  constructor(
+    private readonly challengesRepository: ChallengesRepository,
+    private readonly userChallengesRepository: UserChallengesRepository,
+  ) {}
+
+  async chackedByUserLevel(userId: number, completedLevel: number) {
+    const challenge = await this.challengesRepository.findOneByTypeAndCondition(
+      this.challengeType,
+      completedLevel,
+    );
+    if (!challenge) {
+      throw new NotFoundException('해당 레벨 도전과제가 존재하지 않습니다.');
+    }
+
+    // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
+    const userChallenge =
+      await this.userChallengesRepository.findOneByChallenge(
+        userId,
+        challenge.id,
+      );
+    if (userChallenge) {
+      throw new NotFoundException('유저에게 도전과제가 없습니다.');
+    }
+    if (userChallenge.completed) {
+      return null;
+    }
+
+    //없으면 완료 처리
+    const updateData: UpdateUserChallengesDto = {
+      completed: true,
+      completedDate: new Date(),
+    };
+
+    return this.userChallengesRepository.updateUserChallengesByUserId(
+      userId,
+      challenge.id,
+      updateData,
+    );
+  }
+}

--- a/src/challenges/section-clear-challenges.service.ts
+++ b/src/challenges/section-clear-challenges.service.ts
@@ -31,6 +31,7 @@ export class SectionsChallengesService {
       section.order,
     );
     if (!challenge) {
+      return null;
       throw new NotFoundException('존재하지 않는 도전과제 입니다.');
     }
 
@@ -53,6 +54,7 @@ export class SectionsChallengesService {
         challenge.id,
       );
     if (!userChallenge) {
+      return null;
       throw new NotFoundException('유저에게 도전과제가 없습니다.');
     }
     if (userChallenge.completed) {

--- a/src/challenges/section-clear-challenges.service.ts
+++ b/src/challenges/section-clear-challenges.service.ts
@@ -22,6 +22,7 @@ export class SectionsChallengesService {
     // 섹션 정보를 가져와서 order 값을 확인.
     const section = await this.sectionsRepository.findOneSectionById(sectionId);
     if (!section) {
+      return null;
       throw new NotFoundException('존재하지 않는 섹션입니다.');
     }
 

--- a/src/challenges/section-clear-challenges.service.ts
+++ b/src/challenges/section-clear-challenges.service.ts
@@ -22,7 +22,6 @@ export class SectionsChallengesService {
     // 섹션 정보를 가져와서 order 값을 확인.
     const section = await this.sectionsRepository.findOneSectionById(sectionId);
     if (!section) {
-      return null;
       throw new NotFoundException('존재하지 않는 섹션입니다.');
     }
 
@@ -33,7 +32,19 @@ export class SectionsChallengesService {
     );
     if (!challenge) {
       return null;
-      throw new NotFoundException('존재하지 않는 도전과제 입니다.');
+    }
+
+    // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
+    const userChallenge =
+      await this.userChallengesRepository.findOneByChallenge(
+        userId,
+        challenge.id,
+      );
+    if (!userChallenge) {
+      throw new NotFoundException('유저에게 도전과제가 없습니다.');
+    }
+    if (userChallenge.completed) {
+      return null;
     }
 
     // 사용자의 partProgress 중, COMPLETED가 아닌 항목들을 조회.
@@ -45,20 +56,6 @@ export class SectionsChallengesService {
 
     // 미완료 항목이 있다면 업데이트 없이 종료.
     if (incompleteParts.length) {
-      return null;
-    }
-
-    // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
-    const userChallenge =
-      await this.userChallengesRepository.findOneByChallenge(
-        userId,
-        challenge.id,
-      );
-    if (!userChallenge) {
-      return null;
-      throw new NotFoundException('유저에게 도전과제가 없습니다.');
-    }
-    if (userChallenge.completed) {
       return null;
     }
 

--- a/src/challenges/section-clear-challenges.service.ts
+++ b/src/challenges/section-clear-challenges.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { PartStatus } from '@prisma/client';
 import { ChallengesRepository } from './challenges.repository';
 import { PartProgressRepository } from 'src/part-progress/part-progress.repository';
 import { PartStatusValues } from 'src/part-progress/entities/part-progress.entity';
@@ -19,49 +18,57 @@ export class SectionsChallengesService {
     private readonly userChallengesRepository: UserChallengesRepository,
   ) {}
 
-  async chackedByAllPartStatusCompleted(userId: number, sectionId: number) {
-    //어떤 도전과제에 대한 내용인지 먼저 찾기
-    const challengeType = this.challengeType;
+  async checkAndCompleteSectionChallenge(userId: number, sectionId: number) {
+    // 섹션 정보를 가져와서 order 값을 확인.
+    const section = await this.sectionsRepository.findOneSectionById(sectionId);
+    if (!section) {
+      throw new NotFoundException('존재하지 않는 섹션입니다.');
+    }
 
-    const { order } =
-      await this.sectionsRepository.findOneSectionById(sectionId);
-
-    const chalenge = await this.challengesRepository.findOneByTypeAndCondition(
-      challengeType,
-      order, //이곳에서 condition은 section의 order
+    // 섹션 order를 조건으로 도전과제를 조회.
+    const challenge = await this.challengesRepository.findOneByTypeAndCondition(
+      this.challengeType,
+      section.order,
     );
-
-    if (!chalenge) {
+    if (!challenge) {
       throw new NotFoundException('존재하지 않는 도전과제 입니다.');
     }
 
-    //partProgress중 completed가 아닌 값이 있는지 확인
-    const excludedStatus: PartStatus = PartStatusValues.COMPLETED;
-
-    const filteredPartStatus =
+    // 사용자의 partProgress 중, COMPLETED가 아닌 항목들을 조회.
+    const incompleteParts =
       await this.partProgressRepository.findAllExceptStatusValue(
         userId,
-        excludedStatus,
+        PartStatusValues.COMPLETED,
       );
 
-    //값이 있으면 리턴
-    if (filteredPartStatus.length) {
+    // 미완료 항목이 있다면 업데이트 없이 종료.
+    if (incompleteParts.length) {
       return null;
     }
 
-    //없으면 완료 처리
-    const data: UpdateUserChallengesDto = {
+    // 이미 완료된 도전과제라면, 추가 업데이트 없이 반환
+    const userChallenge =
+      await this.userChallengesRepository.findOneByChallenge(
+        userId,
+        challenge.id,
+      );
+    if (!userChallenge) {
+      throw new NotFoundException('유저에게 도전과제가 없습니다.');
+    }
+    if (userChallenge.completed) {
+      return null;
+    }
+
+    // 모든 part가 완료되었으므로, 도전과제를 완료.
+    const updateData: UpdateUserChallengesDto = {
       completed: true,
       completedDate: new Date(),
     };
 
-    const userChallengeUpdateData =
-      await this.userChallengesRepository.updateUserChallengesByUserId(
-        userId,
-        chalenge.id,
-        data,
-      );
-
-    return userChallengeUpdateData;
+    return this.userChallengesRepository.updateUserChallengesByUserId(
+      userId,
+      challenge.id,
+      updateData,
+    );
   }
 }

--- a/src/challenges/user-challenges/user-challenges.interface.ts
+++ b/src/challenges/user-challenges/user-challenges.interface.ts
@@ -1,5 +1,7 @@
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
 import { Challenge } from '../challenges.interface';
+import { ValueOf } from 'src/common/util/type-utils';
+import { ChallengeTypeValues } from '../const/challenges.constant';
 
 export interface UserChallenge {
   id: number;
@@ -20,3 +22,5 @@ export interface PaginationUserChallenges
     OffsetPaginationBaseResponseDto<UserChallengesAndInfo>,
     'totalPage'
   > {}
+
+export type ChallengeType = ValueOf<typeof ChallengeTypeValues>;

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -40,16 +40,6 @@ export class UserChallengesRepository {
     });
   }
 
-  async findManyByUserAndChallengeIds(
-    userId: number,
-    challengeIds: number[],
-  ): Promise<UserChallenge[]> {
-    return await this.prisma.userChallenge.findMany({
-      where: { userId, challengeId: { in: challengeIds } },
-      orderBy: {},
-    });
-  }
-
   async findManyByUserAndType(
     userId: number,
     lowerCondition: number,
@@ -96,28 +86,6 @@ export class UserChallengesRepository {
       where: { userId_challengeId: { userId, challengeId }, completed: false },
       data,
       include: { challenge: true },
-    });
-  }
-
-  /**
-   * 다중 업데이트를 위한 메서드입니다.
-   * @param userId 특정 유저를 선택
-   * @param challengeIds 업데이트할 도전과제 목록을 가져옴
-   * @param data: 업데이트 할 내용
-   * completed: false인 값만 true로 변경하면서 업데이트 성능을 향상
-   */
-  async updateManyUserChallenges(
-    userId: number,
-    challengeIds: number[],
-    data: UpdateUserChallengesDto,
-  ) {
-    return await this.prisma.userChallenge.updateMany({
-      where: {
-        userId,
-        challengeId: { in: challengeIds },
-        completed: false,
-      },
-      data,
     });
   }
 

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -116,7 +116,7 @@ export class UserChallengesRepository {
 
   //Event 핸들러에서 호출할 서비스 메서드에서 사용
   async updateById(id: number, data: UpdateUserChallengesDto) {
-    return await this.prisma.userChallenge.updateMany({
+    return await this.prisma.userChallenge.update({
       where: { id, completed: false },
       data,
     });

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -40,6 +40,31 @@ export class UserChallengesRepository {
     });
   }
 
+  //Event 핸들러에서 호출할 서비스 메서드에서 사용
+  async findOneByUserAndType(
+    userId: number,
+    lowerCondition: number,
+    challengeType: ChallengeType,
+  ): Promise<UserChallengesAndInfo> {
+    return await this.prisma.userChallenge.findFirst({
+      where: {
+        userId,
+        completed: false,
+        challenge: {
+          challengeType,
+          condition: { lte: lowerCondition },
+        },
+      },
+      include: { challenge: true },
+      orderBy: {
+        challenge: {
+          condition: 'desc',
+        },
+      },
+    });
+  }
+
+  //Event 핸들러에서 호출할 서비스 메서드에서 사용
   async findManyByUserAndType(
     userId: number,
     lowerCondition: number,
@@ -89,6 +114,15 @@ export class UserChallengesRepository {
     });
   }
 
+  //Event 핸들러에서 호출할 서비스 메서드에서 사용
+  async updateById(id: number, data: UpdateUserChallengesDto) {
+    return await this.prisma.userChallenge.updateMany({
+      where: { id, completed: false },
+      data,
+    });
+  }
+
+  //Event 핸들러에서 호출할 서비스 메서드에서 사용
   async updateManyByIds(ids: number[], data: UpdateUserChallengesDto) {
     return await this.prisma.userChallenge.updateMany({
       where: { id: { in: ids }, completed: false },

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -89,7 +89,7 @@ export class UserChallengesRepository {
     });
   }
 
-  async updateManyByUserAndType(ids: number[], data: UpdateUserChallengesDto) {
+  async updateManyByIds(ids: number[], data: UpdateUserChallengesDto) {
     return await this.prisma.userChallenge.updateMany({
       where: { id: { in: ids }, completed: false },
       data,

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -39,6 +39,15 @@ export class UserChallengesRepository {
     });
   }
 
+  async findManyByUserAndChallengeIds(
+    userId: number,
+    challengeIds: number[],
+  ): Promise<UserChallenge[]> {
+    return await this.prisma.userChallenge.findMany({
+      where: { userId, challengeId: { in: challengeIds } },
+    });
+  }
+
   async findOneById(id: number): Promise<UserChallenge> {
     return await this.prisma.userChallenge.findUnique({
       where: { id },
@@ -62,6 +71,28 @@ export class UserChallengesRepository {
       where: { userId_challengeId: { userId, challengeId } },
       data,
       include: { challenge: true },
+    });
+  }
+
+  /**
+   * 다중 업데이트를 위한 메서드입니다.
+   * @param userId 특정 유저를 선택
+   * @param challengeIds 업데이트할 도전과제 목록을 가져옴
+   * @param data: 업데이트 할 내용
+   * completed: false인 값만 true로 변경하면서 업데이트 성능을 향상
+   */
+  async updateManyUserChallenges(
+    userId: number,
+    challengeIds: number[],
+    data: UpdateUserChallengesDto,
+  ) {
+    return await this.prisma.userChallenge.updateMany({
+      where: {
+        userId,
+        challengeId: { in: challengeIds },
+        completed: false,
+      },
+      data,
     });
   }
 }

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -30,6 +30,15 @@ export class UserChallengesRepository {
     });
   }
 
+  async findOneByChallenge(
+    userId: number,
+    challengeId: number,
+  ): Promise<UserChallenge> {
+    return await this.prisma.userChallenge.findUnique({
+      where: { userId_challengeId: { userId, challengeId } },
+    });
+  }
+
   async findOneById(id: number): Promise<UserChallenge> {
     return await this.prisma.userChallenge.findUnique({
       where: { id },

--- a/src/part-progress/part-progress.service.ts
+++ b/src/part-progress/part-progress.service.ts
@@ -12,6 +12,7 @@ import {
   PartStatusValues,
 } from './entities/part-progress.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Evnet } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class PartProgressService {
@@ -106,7 +107,7 @@ export class PartProgressService {
     const completed = new CreatePartProgressDto(PartStatusValues.COMPLETED);
 
     const eventPartStatusCompleted = (userId: number, sectionId: number) => {
-      this.eventEmitter.emit('partStatus.completed', {
+      this.eventEmitter.emit(Evnet.PartStatus.Completed, {
         userId,
         sectionId,
       });

--- a/src/part-progress/part-progress.service.ts
+++ b/src/part-progress/part-progress.service.ts
@@ -12,7 +12,7 @@ import {
   PartStatusValues,
 } from './entities/part-progress.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Evnet } from 'src/challenges/const/challenges.constant';
+import { EVENT } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class PartProgressService {
@@ -107,7 +107,7 @@ export class PartProgressService {
     const completed = new CreatePartProgressDto(PartStatusValues.COMPLETED);
 
     const eventPartStatusCompleted = (userId: number, sectionId: number) => {
-      this.eventEmitter.emit(Evnet.PartStatus.Completed, {
+      this.eventEmitter.emit(EVENT.PART_STATUS.COMPLETED, {
         userId,
         sectionId,
       });

--- a/src/users/controllers/user-experience.controller.ts
+++ b/src/users/controllers/user-experience.controller.ts
@@ -28,9 +28,6 @@ export class UserExperienceController {
     @User() user: UserInfo,
     @Body() updateExperienceData: UpdateExperienceDto,
   ) {
-    return this.experienceService.updateExperience(
-      user.id,
-      updateExperienceData,
-    );
+    return this.experienceService.updateExperience(user, updateExperienceData);
   }
 }

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -8,7 +8,7 @@ import {
 } from '../constants/user-experience.constant';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UserInfo } from '../entities/user.entity';
-import { Evnet } from 'src/challenges/const/challenges.constant';
+import { EVENT } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class UserExperienceService {
@@ -50,7 +50,7 @@ export class UserExperienceService {
     });
 
     // 이벤트 발생
-    this.eventEmitter.emit(Evnet.User.LevelUp, {
+    this.eventEmitter.emit(EVENT.USER.LEVEL_UP, {
       user: updatedExperience,
     });
 

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -6,10 +6,15 @@ import {
   INCREASE_MULTIPLIER,
   LEVEL_UP,
 } from '../constants/user-experience.constant';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { UserInfo } from '../entities/user.entity';
 
 @Injectable()
 export class UserExperienceService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
 
   async getUserExperience(id: number): Promise<ResponseExperienceDto> {
     const userExperience = await this.prisma.user.findUnique({
@@ -23,15 +28,9 @@ export class UserExperienceService {
   }
 
   async updateExperience(
-    id: number,
+    user: UserInfo,
     updateExperienceData: UpdateExperienceDto,
   ): Promise<ResponseExperienceDto> {
-    const user = await this.prisma.user.findUnique({ where: { id } });
-
-    if (!user) {
-      throw new NotFoundException(`id ${id} not found`);
-    }
-
     const { userLevel, userExperience, experienceForNextLevel } =
       this.calculateLevel(
         user.level,
@@ -41,13 +40,17 @@ export class UserExperienceService {
       );
 
     const updatedExperience = await this.prisma.user.update({
-      where: { id },
+      where: { id: user.id },
       data: {
         level: userLevel,
         experience: userExperience,
         experienceForNextLevel: experienceForNextLevel,
       },
     });
+
+    // 이벤트 발생
+    this.emitMissingLevelMilestoneEvents(user, updatedExperience);
+
     return new ResponseExperienceDto(updatedExperience);
   }
 
@@ -66,5 +69,35 @@ export class UserExperienceService {
       );
     }
     return { userLevel, userExperience, experienceForNextLevel };
+  }
+
+  /**
+   * 기존 레벨과 업데이트 된 후의 레벨을 비교해서 레벨 도전과제 이벤트를 몇번 실행해야할지 계산함
+   * 예를 들어
+   *
+   * 기존 레벨: 8, 업데이트된 레벨: 21 일 경우
+   * user.level10Up 이벤트: { userInfo, 10 },
+   * user.level10Up 이벤트: { userInfo, 20 }
+   * 두개의 이벤트를 발생함
+   *
+   * @param oldUser
+   * @param updatedUser
+   */
+  private emitMissingLevelMilestoneEvents(
+    oldUser: UserInfo,
+    updatedUser: UserInfo,
+  ): void {
+    for (
+      let completedLevel = 10;
+      completedLevel <= updatedUser.level;
+      completedLevel += 10
+    ) {
+      if (completedLevel > oldUser.level) {
+        this.eventEmitter.emit('user.level10Up', {
+          userId: updatedUser.id,
+          completedLevel,
+        });
+      }
+    }
   }
 }

--- a/src/users/services/user-experience.service.ts
+++ b/src/users/services/user-experience.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../constants/user-experience.constant';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UserInfo } from '../entities/user.entity';
+import { Evnet } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class UserExperienceService {
@@ -49,7 +50,9 @@ export class UserExperienceService {
     });
 
     // 이벤트 발생
-    this.emitMissingLevelMilestoneEvents(user, updatedExperience);
+    this.eventEmitter.emit(Evnet.User.LevelUp, {
+      user: updatedExperience,
+    });
 
     return new ResponseExperienceDto(updatedExperience);
   }
@@ -69,35 +72,5 @@ export class UserExperienceService {
       );
     }
     return { userLevel, userExperience, experienceForNextLevel };
-  }
-
-  /**
-   * 기존 레벨과 업데이트 된 후의 레벨을 비교해서 레벨 도전과제 이벤트를 몇번 실행해야할지 계산함
-   * 예를 들어
-   *
-   * 기존 레벨: 8, 업데이트된 레벨: 21 일 경우
-   * user.level10Up 이벤트: { userInfo, 10 },
-   * user.level10Up 이벤트: { userInfo, 20 }
-   * 두개의 이벤트를 발생함
-   *
-   * @param oldUser
-   * @param updatedUser
-   */
-  private emitMissingLevelMilestoneEvents(
-    oldUser: UserInfo,
-    updatedUser: UserInfo,
-  ): void {
-    for (
-      let completedLevel = 10;
-      completedLevel <= updatedUser.level;
-      completedLevel += 10
-    ) {
-      if (completedLevel > oldUser.level) {
-        this.eventEmitter.emit('user.level10Up', {
-          userId: updatedUser.id,
-          completedLevel,
-        });
-      }
-    }
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

#149 

## 📝작업 내용

![image](https://github.com/user-attachments/assets/5aec1e3f-ffcb-428a-b173-69a1133dd818)

도전과제 레벨 10 달성, 20달성 등
레벨 클리어에 관한 도전과제 달성을 체크하는 세부로직 입니다.

1. challenge 모듈에서  challenge.event -> level-clear-challenge.service -> 각 모듈의 repository 로
 이어지는 흐름의 이벤트 로직을 작성했습니다. 이벤트 트리거는 progress 모듈의 progress서비스의 upsert메서드 실행입니다.

2.  level-clear-challenge.service 세부 로직입니다.
1) 유저 정보와 클래스 내부 타입으로 유저 도전과제를 조회후 업데이트 해줍니다.


## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
