### PR TITLE
GET /users/me/challenges api 페이지네이션 요청에 정렬 추가

### DIFF
--- a/src/challenges/challenges.repository.ts
+++ b/src/challenges/challenges.repository.ts
@@ -38,6 +38,18 @@ export class ChallengesRepository {
     });
   }
 
+  async findOneByChallengeTypeAndCondition({
+    challengeType,
+    condition,
+  }: {
+    challengeType: ChallengeType;
+    condition: number;
+  }): Promise<Challenge> {
+    return await this.prisma.challenge.findUnique({
+      where: { challengeType_condition: { challengeType, condition } },
+    });
+  }
+
   async findOneByTypeAndCondition(
     challengeType: ChallengeType,
     condition: number,

--- a/src/challenges/challenges.repository.ts
+++ b/src/challenges/challenges.repository.ts
@@ -17,10 +17,12 @@ export class ChallengesRepository {
   async findSelectedPageChallengesInfo(
     page: number,
     limit: number,
+    challengeType?: ChallengeType,
   ): Promise<Challenge[]> {
     return await this.prisma.challenge.findMany({
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수
+      where: { ...(challengeType && { challengeType }) },
     });
   }
 

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -9,6 +9,7 @@ import { ChallengesRepository } from './challenges.repository';
 import { QueryChallengesDto } from './dto/query-challenges.dto';
 import { Challenge, PaginationChallenges } from './challenges.interface';
 import { UsersRepository } from 'src/users/repositories/users.reposirory';
+import { ChallengeType } from './user-challenges/user-challenges.interface';
 
 @Injectable()
 export class ChallengesService {
@@ -62,10 +63,29 @@ export class ChallengesService {
     return challenges;
   }
 
+  async chackedTypeAndConditionUnique(typeAndCondition: {
+    challengeType: ChallengeType;
+    condition: number;
+  }): Promise<Challenge> {
+    const challenges =
+      await this.challengesRepository.findOneByChallengeTypeAndCondition(
+        typeAndCondition,
+      );
+
+    if (challenges) {
+      throw new ConflictException(
+        `도전과제 타입과 컨디션의 조합은 유니크 해야합니다.`,
+      );
+    }
+
+    return challenges;
+  }
+
   async create(body: CreateChallengesDto): Promise<Challenge> {
     const { badgeName } = body;
 
     await this.chackedBadgeName(badgeName);
+    await this.chackedTypeAndConditionUnique(body);
 
     const allUsers = await this.usersRepository.findAllUsers();
 

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -20,7 +20,7 @@ export class ChallengesService {
   async findAllByPageAndLimit(
     query: QueryChallengesDto,
   ): Promise<PaginationChallenges> {
-    const { page, limit } = query;
+    const { page, limit, challengeType } = query;
     const allChallengesCount =
       await this.challengesRepository.getTotalChallengesCount();
 
@@ -28,6 +28,7 @@ export class ChallengesService {
       await this.challengesRepository.findSelectedPageChallengesInfo(
         page,
         limit,
+        challengeType,
       );
 
     return {

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -103,11 +103,17 @@ export class ChallengesService {
     challengeId: number,
     body: UpdateChallengesDto,
   ): Promise<Challenge> {
-    const { badgeName } = body;
+    const { badgeName, challengeType, condition } = body;
 
     await this.findOne(challengeId);
 
-    badgeName && (await this.chackedBadgeName(badgeName));
+    if (badgeName) {
+      await this.chackedBadgeName(badgeName);
+    }
+
+    if (challengeType && condition) {
+      await this.chackedTypeAndConditionUnique({ challengeType, condition });
+    }
 
     return await this.challengesRepository.updateChallengesById(
       challengeId,

--- a/src/challenges/dto/query-challenges.dto.ts
+++ b/src/challenges/dto/query-challenges.dto.ts
@@ -1,7 +1,9 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
 import { PaginationDefaults } from 'src/common/constants/rankings-constants';
+import { ChallengeType } from '../user-challenges/user-challenges.interface';
+import { ChallengeTypeValues } from '../const/challenges.constant';
 
 export class QueryChallengesDto {
   @ApiPropertyOptional({
@@ -25,4 +27,13 @@ export class QueryChallengesDto {
   @Min(1)
   @Type(() => Number)
   readonly page?: number = PaginationDefaults.PAGE_NUMBER;
+
+  @ApiPropertyOptional({
+    description: `ChallengeType값(enum) 넣기`,
+    example: ChallengeTypeValues.LEVEL_CLEAR,
+    enum: ChallengeTypeValues,
+  })
+  @IsOptional()
+  @IsEnum(ChallengeTypeValues, { message: 'bad challenge type' })
+  readonly challengeType?: ChallengeType;
 }

--- a/src/challenges/dto/res-challenges.dto.ts
+++ b/src/challenges/dto/res-challenges.dto.ts
@@ -51,6 +51,7 @@ export class ResChallengesDto
     this.content = challenges.content;
     this.point = challenges.point;
     this.experience = challenges.experience;
+    this.challengeType = challenges.challengeType;
     this.condition = challenges.condition;
     this.badgeName = challenges.badgeName;
   }

--- a/src/challenges/level-clear-challenges.service.ts
+++ b/src/challenges/level-clear-challenges.service.ts
@@ -18,8 +18,8 @@ export class LevelClearChallengesService {
     const userChallenges =
       await this.userChallengesRepository.findManyByUserAndType(
         user.id,
-        user.level,
         this.challengeType,
+        user.level,
       );
 
     const userChallengeIds = userChallenges.map(

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -22,9 +22,10 @@ export class UserChallengesRepository {
     userId: number,
     page: number,
     limit: number,
+    challengeType: ChallengeType,
   ): Promise<UserChallengesAndInfo[]> {
     return await this.prisma.userChallenge.findMany({
-      where: { userId },
+      where: { userId, challenge: { challengeType } },
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수
       include: { challenge: true },

--- a/src/challenges/user-challenges/user-challenges.service.ts
+++ b/src/challenges/user-challenges/user-challenges.service.ts
@@ -18,7 +18,7 @@ export class UserChallengesService {
     userId: number,
     query: QueryChallengesDto,
   ): Promise<PaginationUserChallenges> {
-    const { page, limit } = query;
+    const { page, limit, challengeType } = query;
     const allUserChallengessCount =
       await this.userChallengesRepository.getTotalUserChallengesCount(userId);
 
@@ -27,6 +27,7 @@ export class UserChallengesService {
         userId,
         page,
         limit,
+        challengeType,
       );
 
     return {


### PR DESCRIPTION
## 🔗 관련 이슈

#159 

## 📝작업 내용

<img width="530" alt="image" src="https://github.com/user-attachments/assets/516ed05e-f833-4bf1-ae03-61ca983509b7" />

기존 페이지네이션을 위해 받던 page, limit 값 말고도 정렬을위한 challengeType 값을 url쿼리스트링으로 받습니다.
이제 challengeType 별로 정렬이 가능합니다.

추가사항으로
POST /challenges 요청시 유니크값인 challengeType과 condition값의 조합을 
확인하지 않는걸 보고 
조합값 유니크를 확인하는 코드를 추가했습니다.

```ts
async chackedTypeAndConditionUnique(typeAndCondition: {
    challengeType: ChallengeType;
    condition: number;
  }): Promise<Challenge> {
    const challenges =
      await this.challengesRepository.findOneByChallengeTypeAndCondition(
        typeAndCondition,
      );

    if (challenges) {
      throw new ConflictException(
        `도전과제 타입과 컨디션의 조합은 유니크 해야합니다.`,
      );
    }

    return challenges;
  }
```

## 🔍 변경 사항

- [x] GET /users/me/challenges api  정렬 추가
- [x] 겸사겸사 GET /challenges api  정렬 추가

## 💬리뷰 요구사항 (선택사항)
