### PR TITLE
Feat/#170/users challenge api add orderby

### DIFF
--- a/src/challenges/user-challenges/dto/query-user-challenges.dto.ts
+++ b/src/challenges/user-challenges/dto/query-user-challenges.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import { IsBoolean, IsOptional } from 'class-validator';
 import { QueryChallengesDto } from 'src/challenges/dto/query-challenges.dto';
 

--- a/src/challenges/user-challenges/dto/query-user-challenges.dto.ts
+++ b/src/challenges/user-challenges/dto/query-user-challenges.dto.ts
@@ -1,0 +1,17 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { QueryChallengesDto } from 'src/challenges/dto/query-challenges.dto';
+
+export class QueryUserChallengesDto extends QueryChallengesDto {
+  @ApiPropertyOptional({
+    description: '도전과제 완료부터 받을지 아닐지 정렬, boolean 넣으세용',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    return value === 'true' || value === true;
+  })
+  readonly completed?: boolean;
+}

--- a/src/challenges/user-challenges/user-challenges.controller.ts
+++ b/src/challenges/user-challenges/user-challenges.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { UserChallengesService } from './user-challenges.service';
-import { QueryChallengesDto } from '../dto/query-challenges.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/get-user.decorator';
 import { UserInfo } from 'src/users/entities/user.entity';
 import { ResUserChallengesPaginationDto } from './dto/res-user-challenges-pagination.dto';
 import { ApiChallenges } from '../challenges.swagger';
+import { QueryUserChallengesDto } from './dto/query-user-challenges.dto';
 
 @ApiTags('challenges')
 @Controller('users/me/challenges')
@@ -18,7 +18,7 @@ export class UserChallengesController {
   @UseGuards(AuthGuard('accessToken'))
   async findAllUserChallenges(
     @User() user: UserInfo,
-    @Query() query: QueryChallengesDto,
+    @Query() query: QueryUserChallengesDto,
   ): Promise<ResUserChallengesPaginationDto> {
     const paginationData =
       await this.userChallengesService.findAllByPageAndLimit(user.id, query);

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -25,14 +25,12 @@ export class UserChallengesRepository {
     challengeType: ChallengeType,
     completed: boolean,
   ): Promise<UserChallengesAndInfo[]> {
-    console.log('completed', completed);
     return await this.prisma.userChallenge.findMany({
       where: { userId, challenge: { challengeType } },
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수
       include: { challenge: true },
       orderBy: { completed: completed ? 'desc' : 'asc' },
-      //orderBy: { completed: 'asc' },
     });
   }
 

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -23,12 +23,16 @@ export class UserChallengesRepository {
     page: number,
     limit: number,
     challengeType: ChallengeType,
+    completed: boolean,
   ): Promise<UserChallengesAndInfo[]> {
+    console.log('completed', completed);
     return await this.prisma.userChallenge.findMany({
       where: { userId, challenge: { challengeType } },
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수
       include: { challenge: true },
+      orderBy: { completed: completed ? 'desc' : 'asc' },
+      //orderBy: { completed: 'asc' },
     });
   }
 

--- a/src/challenges/user-challenges/user-challenges.service.ts
+++ b/src/challenges/user-challenges/user-challenges.service.ts
@@ -1,12 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateUserChallengesDto } from './dto/create-user-challenges.dto';
-import { UpdateUserChallengesDto } from './dto/update-user-challenges.dto';
 import { UserChallengesRepository } from './user-challenges.repository';
-import { QueryChallengesDto } from '../dto/query-challenges.dto';
 import {
   PaginationUserChallenges,
   UserChallenge,
 } from './user-challenges.interface';
+import { QueryUserChallengesDto } from './dto/query-user-challenges.dto';
 
 @Injectable()
 export class UserChallengesService {
@@ -16,9 +15,9 @@ export class UserChallengesService {
 
   async findAllByPageAndLimit(
     userId: number,
-    query: QueryChallengesDto,
+    query: QueryUserChallengesDto,
   ): Promise<PaginationUserChallenges> {
-    const { page, limit, challengeType } = query;
+    const { page, limit, challengeType, completed } = query;
     const allUserChallengessCount =
       await this.userChallengesRepository.getTotalUserChallengesCount(userId);
 
@@ -28,6 +27,7 @@ export class UserChallengesService {
         page,
         limit,
         challengeType,
+        completed,
       );
 
     return {


### PR DESCRIPTION
## 🔗 관련 이슈

#170 

## 📝작업 내용

클라이언트에서 유저 도전과제를 조회할때, 도전과제 완료여부에 따라 정렬되는 기능 추가가 필요해
기능을 추가합니다.

쿼리로 completed 값을 불리언 값으로 받습니다.

이후 이 값으로 데이터베이스에 orderBy 값으로 넣습니다.

결과적으로 유저가 완료한 도전과제가 먼저 보이거나, 완료하지 못한 도전과제가 먼저보이는 등의 기능을 사용할 수 있습니다.

## 🔍 변경 사항

- [ ] 정렬 쿼리 추가

## 💬리뷰 요구사항 (선택사항)
