### PR TITLE
유저도전과제 orderby 옵션을 더 명확하게 정의

### DIFF
--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -34,7 +34,11 @@ export class UserChallengesRepository {
       skip: (page - 1) * limit, // 건너뛸 항목 수 계산
       take: limit, // 가져올 항목 수
       include: { challenge: true },
-      orderBy: { completed: 'desc' },
+      orderBy: [
+        { completed: 'desc' },
+        { challenge: { challengeType: 'desc' } },
+        { challenge: { condition: 'asc' } },
+      ],
     });
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

#170 

## 📝작업 내용

유저 도전과제를 배열로 보열줄때, 기존 true를 먼저 보여주는것에 추가해

1. 타입별로 정렬 , 내림차순
2. conditon으로 다시정렬, 올림차순

두 옵션을 넣어서 더 명확한 순서로 보여줍니다.

이제 클라이언트는 

1. 도전과제 완료를 먼저봄
2. 도전과제 실패 중 타입별로 묶어서 보여짐
3. 도전과제 타입들 중에는 conditons 올림차순으로 보임 ( 7일연속 -> 14일연속-> 21연속 또는 1섹션 -> 2섹션 -> 3섹션 이런식)

위와같은 순서로 정보를 받습니다.
## 🔍 변경 사항

- [x] orderby 추가

## 💬리뷰 요구사항 (선택사항)
