### PR TITLE
"처음으로 문제를 틀림" 도전과제 세부로직

### DIFF
--- a/src/challenges/challenges.module.ts
+++ b/src/challenges/challenges.module.ts
@@ -13,6 +13,7 @@ import { AttendanceStreakChallengesService } from './attendance-streak-challenge
 import { AttendanceModule } from 'src/attendance/attendance.module';
 import { RankingChallengesService } from './ranking-challenges.service';
 import { FirstItemBuyChallengesService } from './first-item-buy.challenges.service';
+import { FirstWrongAnswerChallengesService } from './first-wrong-answer.challenges.service';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { FirstItemBuyChallengesService } from './first-item-buy.challenges.servi
     LevelClearChallengesService,
     AttendanceStreakChallengesService,
     RankingChallengesService,
+    FirstWrongAnswerChallengesService,
 
     ChallengesEventsListener,
   ],

--- a/src/challenges/challenges.repository.ts
+++ b/src/challenges/challenges.repository.ts
@@ -5,13 +5,17 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 import { Challenge } from './challenges.interface';
 import { ChallengeType } from './user-challenges/user-challenges.interface';
+import { QueryChallengesDto } from './dto/query-challenges.dto';
 
 @Injectable()
 export class ChallengesRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getTotalChallengesCount(): Promise<number> {
-    return await this.prisma.challenge.count();
+  async getTotalChallengesCount(query: QueryChallengesDto): Promise<number> {
+    const { challengeType } = query;
+    return await this.prisma.challenge.count({
+      where: { ...(challengeType && { challengeType }) },
+    });
   }
 
   async findSelectedPageChallengesInfo(

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -23,7 +23,7 @@ export class ChallengesService {
   ): Promise<PaginationChallenges> {
     const { page, limit, challengeType } = query;
     const allChallengesCount =
-      await this.challengesRepository.getTotalChallengesCount();
+      await this.challengesRepository.getTotalChallengesCount(query);
 
     const challenges =
       await this.challengesRepository.findSelectedPageChallengesInfo(

--- a/src/challenges/const/challenges.constant.ts
+++ b/src/challenges/const/challenges.constant.ts
@@ -43,4 +43,7 @@ export const EVENT = {
   PROGRESS: {
     UPDATED: 'progress.updated',
   },
+  QUIZ: {
+    INCORRECT: 'quiz.incorrect',
+  },
 } as const;

--- a/src/challenges/const/challenges.constant.ts
+++ b/src/challenges/const/challenges.constant.ts
@@ -40,4 +40,7 @@ export const EVENT = {
   ITEM: {
     BUY: 'item.buy',
   },
+  PROGRESS: {
+    UPDATED: 'progress.updated',
+  },
 } as const;

--- a/src/challenges/dto/query-challenges.dto.ts
+++ b/src/challenges/dto/query-challenges.dto.ts
@@ -8,7 +8,7 @@ import { ChallengeTypeValues } from '../const/challenges.constant';
 export class QueryChallengesDto {
   @ApiPropertyOptional({
     description: '페이지 크기',
-    example: PaginationDefaults.PAGE_LIMIT,
+    example: 100,
     default: PaginationDefaults.PAGE_LIMIT,
   })
   @IsOptional()
@@ -30,7 +30,6 @@ export class QueryChallengesDto {
 
   @ApiPropertyOptional({
     description: `ChallengeType값(enum) 넣기`,
-    example: ChallengeTypeValues.LEVEL_CLEAR,
     enum: ChallengeTypeValues,
   })
   @IsOptional()

--- a/src/challenges/events/challenges.event.ts
+++ b/src/challenges/events/challenges.event.ts
@@ -8,6 +8,7 @@ import { UserInfo } from 'src/users/entities/user.entity';
 import { EVENT } from '../const/challenges.constant';
 import { AttendanceStreakChallengesService } from '../attendance-streak-challenges.service';
 import { RankingChallengesService } from '../ranking-challenges.service';
+import { Progress } from 'src/progress/entities/progress.entity';
 
 @Injectable()
 export class ChallengesEventsListener {
@@ -145,6 +146,30 @@ export class ChallengesEventsListener {
       //sse메시지
       this.sseService.notifyUser(userId, {
         type: EVENT.ITEM.BUY,
+        message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  /**
+   * 퀴즈 진행도가 업데이트 되면 호출되는 이벤트
+   * @param payload
+   */
+  @OnEvent(EVENT.QUIZ.INCORRECT)
+  async handleFirstWrongAnswerChallenge(payload: {
+    userId: number;
+    isCorrect: boolean;
+  }) {
+    const { userId } = payload;
+
+    const userChallengesAndInfo =
+      await this.요기에집어넣으시옹.completedChallenge(userId);
+
+    if (userChallengesAndInfo) {
+      //sse메시지
+      this.sseService.notifyUser(userId, {
+        type: EVENT.QUIZ.INCORRECT,
         message: `도전과제 완료 : ${userChallengesAndInfo.challenge.content}`,
         timestamp: new Date().toISOString(),
       });

--- a/src/challenges/events/challenges.event.ts
+++ b/src/challenges/events/challenges.event.ts
@@ -8,7 +8,7 @@ import { UserInfo } from 'src/users/entities/user.entity';
 import { EVENT } from '../const/challenges.constant';
 import { AttendanceStreakChallengesService } from '../attendance-streak-challenges.service';
 import { RankingChallengesService } from '../ranking-challenges.service';
-import { Progress } from 'src/progress/entities/progress.entity';
+import { FirstWrongAnswerChallengesService } from '../first-wrong-answer.challenges.service';
 
 @Injectable()
 export class ChallengesEventsListener {
@@ -19,6 +19,7 @@ export class ChallengesEventsListener {
     private readonly attendanceStreakChallengesService: AttendanceStreakChallengesService,
     private readonly rankingChallengesService: RankingChallengesService,
     private readonly firstItemBuyChallengesService: FirstItemBuyChallengesService,
+    private readonly firstWrongAnswerChallengesService: FirstWrongAnswerChallengesService,
   ) {}
 
   /**
@@ -157,14 +158,11 @@ export class ChallengesEventsListener {
    * @param payload
    */
   @OnEvent(EVENT.QUIZ.INCORRECT)
-  async handleFirstWrongAnswerChallenge(payload: {
-    userId: number;
-    isCorrect: boolean;
-  }) {
+  async handleFirstWrongAnswerChallenge(payload: { userId: number }) {
     const { userId } = payload;
 
     const userChallengesAndInfo =
-      await this.요기에집어넣으시옹.completedChallenge(userId);
+      await this.firstWrongAnswerChallengesService.completedChallenge(userId);
 
     if (userChallengesAndInfo) {
       //sse메시지

--- a/src/challenges/first-wrong-answer.challenges.service.ts
+++ b/src/challenges/first-wrong-answer.challenges.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { UserChallengesRepository } from './user-challenges/user-challenges.repository';
+import { ChallengeTypeValues } from './const/challenges.constant';
+
+@Injectable()
+export class FirstWrongAnswerChallengesService {
+  private readonly challengeType = ChallengeTypeValues.FIRST_WRONG_ANSWER;
+
+  constructor(
+    private readonly userChallengesRepository: UserChallengesRepository,
+  ) {}
+
+  async completedChallenge(userId: number) {
+    const userChallengesForUpdate =
+      await this.userChallengesRepository.findManyByUserAndType(
+        userId,
+        this.challengeType,
+      );
+
+    if (userChallengesForUpdate.length === 0) {
+      return null;
+    }
+
+    const userChallengeIds = userChallengesForUpdate.map(
+      (userChallenge) => userChallenge.id,
+    );
+
+    // 위에서 가져온 도전과제들을 complete로 변경
+    await this.userChallengesRepository.updateManyByIds(userChallengeIds, {
+      completed: true,
+      completedDate: new Date(),
+    });
+
+    const [first, ...order] = userChallengesForUpdate;
+
+    return first;
+  }
+}

--- a/src/challenges/user-challenges/user-challenges.repository.ts
+++ b/src/challenges/user-challenges/user-challenges.repository.ts
@@ -7,14 +7,25 @@ import {
 } from './user-challenges.interface';
 import { CreateUserChallengesDto } from './dto/create-user-challenges.dto';
 import { UpdateUserChallengesDto } from './dto/update-user-challenges.dto';
+import { QueryUserChallengesDto } from './dto/query-user-challenges.dto';
 
 @Injectable()
 export class UserChallengesRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getTotalUserChallengesCount(userId: number): Promise<number> {
+  async getTotalUserChallengesCount(
+    userId: number,
+    query: QueryUserChallengesDto,
+  ): Promise<number> {
+    const { challengeType, completed } = query;
     return await this.prisma.userChallenge.count({
-      where: { userId },
+      where: {
+        userId,
+        ...(completed === undefined ? {} : { completed }),
+        challenge: {
+          ...(challengeType && { challengeType }),
+        },
+      },
     });
   }
 

--- a/src/challenges/user-challenges/user-challenges.service.ts
+++ b/src/challenges/user-challenges/user-challenges.service.ts
@@ -19,7 +19,10 @@ export class UserChallengesService {
   ): Promise<PaginationUserChallenges> {
     const { page, limit, challengeType, completed } = query;
     const allUserChallengessCount =
-      await this.userChallengesRepository.getTotalUserChallengesCount(userId);
+      await this.userChallengesRepository.getTotalUserChallengesCount(
+        userId,
+        query,
+      );
 
     const userChallengess =
       await this.userChallengesRepository.findSelectedPageUserChallengessInfo(

--- a/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
+++ b/src/daily-quests/users-daily-quests/users-daily-quests.service.ts
@@ -11,6 +11,7 @@ import { DAILY_RESET } from './const/users-daily-quests.const';
 import { OnEvent } from '@nestjs/event-emitter';
 import { Progress } from 'src/progress/entities/progress.entity';
 import { ProgressRepository } from 'src/progress/progress.repository';
+import { EVENT } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class UsersDailyQuestsService {
@@ -98,7 +99,7 @@ export class UsersDailyQuestsService {
     return this.usersDailyQuestsRepository.deleteAll();
   }
 
-  @OnEvent('progress.updated')
+  @OnEvent(EVENT.PROGRESS.UPDATED)
   async handleProgressUpdatedEvent(progress: Progress) {
     await this.update(progress.userId);
   }

--- a/src/progress/progress.service.ts
+++ b/src/progress/progress.service.ts
@@ -79,7 +79,6 @@ export class ProgressService {
     } else {
       this.eventEmitter.emit(EVENT.QUIZ.INCORRECT, {
         userId,
-        isCorrect: progress.isCorrect,
       });
     }
 

--- a/src/progress/progress.service.ts
+++ b/src/progress/progress.service.ts
@@ -76,6 +76,11 @@ export class ProgressService {
         userId,
         isCorrect: progress.isCorrect,
       });
+    } else {
+      this.eventEmitter.emit(EVENT.QUIZ.INCORRECT, {
+        userId,
+        isCorrect: progress.isCorrect,
+      });
     }
 
     // progress 업데이트가 완료된 후 이벤트 발행

--- a/src/progress/progress.service.ts
+++ b/src/progress/progress.service.ts
@@ -9,6 +9,7 @@ import { QuizzesRepository } from 'src/quizzes/quizzes.repository';
 import { ResProgressDto } from './dto/res-progress.dto';
 import { Progress } from './entities/progress.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EVENT } from 'src/challenges/const/challenges.constant';
 
 @Injectable()
 export class ProgressService {
@@ -78,7 +79,7 @@ export class ProgressService {
     }
 
     // progress 업데이트가 완료된 후 이벤트 발행
-    this.eventEmitter.emit('progress.updated', progress);
+    this.eventEmitter.emit(EVENT.PROGRESS.UPDATED, progress);
 
     return progress;
   }


### PR DESCRIPTION
## 🔗 관련 이슈

#156 

## 📝작업 내용

<img width="413" alt="image" src="https://github.com/user-attachments/assets/a972a723-aa0e-4363-afa2-170f95987a65" />
<img width="343" alt="image" src="https://github.com/user-attachments/assets/116a913e-1671-4d05-ae37-315c79d17585" />

도전과제 중
"처음으로 문제를 틀림" 도전과제를 서버에서 확인하는 작업입니다.
이전 작업들과 비슷한 작업입니다.

추가적으로 
요즘 작성중에 드는 생각은, 세부 유저 도전과제 서비스들의 로직이 안그래도 비슷한데,
특히 "처음 아이템구매", "처음 문제를 트림" 도전과제 등 앞으로 **이벤트**라고 명시할 도전과제들은
완전 똑같은 코드가 중복되고 있어서 이 중복을 어떤식으로 없앨지 고민이 됩니다. 

## 🔍 변경 사항

- [x] 이벤트 상수 작성
- [x] 도전과제 서비스 하나 추가 작성및 적용

## 💬리뷰 요구사항 (선택사항)
