### PR TITLE
유저 아이템 장착여부 조회 api의 res정보데이터 변경

### DIFF
--- a/src/items/dto/response-item.dto.ts
+++ b/src/items/dto/response-item.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Item } from '@prisma/client';
 
-export class ItemDto {
+export class ItemDto implements Item {
   @ApiProperty({
     description: '아이템 ID',
     example: 1,
@@ -37,6 +38,15 @@ export class ItemDto {
     required: false,
   })
   subCategoryId: number | null;
+
+  constructor(item: Item) {
+    this.id = item.id;
+    this.name = item.name;
+    this.image = item.image;
+    this.price = item.price;
+    this.mainCategoryId = item.mainCategoryId;
+    this.subCategoryId = item.subCategoryId;
+  }
 }
 
 export class PaginatedItemsResponseDto {
@@ -49,6 +59,5 @@ export class PaginatedItemsResponseDto {
   @ApiProperty({ description: '현재 페이지', example: 1 })
   currentPage: number;
 
-  @ApiProperty({ description: '아이템 목록', type: [ItemDto] })
   contents: ItemDto[];
 }

--- a/src/items/items.service.ts
+++ b/src/items/items.service.ts
@@ -11,6 +11,7 @@ import { Item } from '@prisma/client';
 import { ItemsRepository } from './items.repository';
 import { ItemsPaginationResponseDto } from './dto/items-pagination-response.dto';
 import { itemsPaginationQueryDto } from './dto/items-pagination-query.dto';
+import { ItemDto } from './dto/response-item.dto';
 
 @Injectable()
 export class ItemsService {
@@ -97,7 +98,7 @@ export class ItemsService {
     if (!item) {
       throw new NotFoundException(`아이템을 찾을 수 없습니다. ID: ${id}`);
     }
-    return item;
+    return new ItemDto(item);
   }
 
   async updateItem(id: number, body: UpdateItemDto) {

--- a/src/users/controllers/user-items.controller.ts
+++ b/src/users/controllers/user-items.controller.ts
@@ -22,10 +22,9 @@ import { ApiResetEquipment } from '../swagger-decorator/put-user-items.decorator
 import { User } from 'src/common/decorators/get-user.decorator';
 import { UserInfo } from 'src/users/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
-import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
-import { UserItem } from 'src/users/entities/user-item.entity';
 import { UserItemsQueryDto } from '../dtos/userItems-query.dto';
 import { ResponseUserEquippedDto } from '../dtos/response-user-equipped.dto';
+import { UserItemsPaginationResponseDto } from '../dtos/response-userItems-pagination.dto';
 
 @ApiTags('user-items')
 @Controller('users/me/items')
@@ -40,7 +39,7 @@ export class UserItemsController {
   async getUserItemsByCategory(
     @User() user: UserInfo,
     @Query() query: UserItemsPaginationQueryDto,
-  ): Promise<OffsetPaginationBaseResponseDto<UserItem>> {
+  ): Promise<UserItemsPaginationResponseDto> {
     return this.userItemsService.getUserItemsByCategory(user.id, query);
   }
 

--- a/src/users/controllers/user-items.controller.ts
+++ b/src/users/controllers/user-items.controller.ts
@@ -25,6 +25,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
 import { UserItem } from 'src/users/entities/user-item.entity';
 import { UserItemsQueryDto } from '../dtos/userItems-query.dto';
+import { ResponseUserEquippedDto } from '../dtos/response-user-equipped.dto';
 
 @ApiTags('user-items')
 @Controller('users/me/items')
@@ -82,8 +83,12 @@ export class UserItemsController {
   async getEquippedUserItems(
     @User() user: UserInfo,
     @Query() query: UserItemsQueryDto,
-  ): Promise<UserItem[]> {
-    return this.userItemsService.getEquippedUserItems(user.id, query);
+  ): Promise<ResponseUserEquippedDto[]> {
+    const response = await this.userItemsService.getEquippedUserItems(
+      user.id,
+      query,
+    );
+    return ResponseUserEquippedDto.fromArray(response);
   }
 
   //5. 장착 아이템 초기화

--- a/src/users/dtos/response-user-equipped.dto.ts
+++ b/src/users/dtos/response-user-equipped.dto.ts
@@ -1,0 +1,47 @@
+import { Item } from 'src/items/entities/item.entity';
+import { UserItem } from '../entities/user-item.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResponseUserEquippedDto implements Item {
+  @ApiProperty({
+    example: 1,
+    description: '아이템 아이디',
+  })
+  readonly id: number;
+
+  @ApiProperty({
+    example: '바지2',
+    description: '아이템 이름',
+  })
+  readonly name: string;
+
+  @ApiProperty({
+    example: 1000,
+    description: '아이템 가격',
+  })
+  readonly price: number;
+
+  @ApiProperty({
+    example: 'itme.png',
+    description: '아이템 이미지네임',
+  })
+  readonly image: string;
+
+  @ApiProperty({
+    example: false,
+    description: '장착 여부',
+  })
+  readonly isEquipped: boolean;
+
+  constructor(userItem: UserItem) {
+    this.id = userItem.item.id;
+    this.name = userItem.item.name;
+    this.price = userItem.item.price;
+    this.image = userItem.item.image;
+    this.isEquipped = userItem.isEquipped;
+  }
+
+  static fromArray(userItems: UserItem[]): ResponseUserEquippedDto[] {
+    return userItems.map((userItem) => new ResponseUserEquippedDto(userItem));
+  }
+}

--- a/src/users/dtos/response-userItems-pagination.dto.ts
+++ b/src/users/dtos/response-userItems-pagination.dto.ts
@@ -1,13 +1,19 @@
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
 import { UserItem } from '../entities/user-item.entity';
-import { Item } from 'src/items/entities/item.entity';
+import { ResponseUserEquippedDto } from './response-user-equipped.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
-export class UserItemsPaginationResponseDto extends OffsetPaginationBaseResponseDto<
-  UserItem & { item: Item }
-> {
-  readonly contents: (UserItem & { item: Item })[];
-  constructor(props: Omit<UserItemsPaginationResponseDto, 'totalPage'>) {
-    super(props);
-    this.contents = props.contents;
+export class UserItemsPaginationResponseDto extends OffsetPaginationBaseResponseDto<ResponseUserEquippedDto> {
+  @ApiProperty({
+    description: '아이템객체 + 유저아이템 장작여부',
+    type: [ResponseUserEquippedDto],
+  })
+  readonly contents: ResponseUserEquippedDto[];
+  constructor(
+    props: Omit<OffsetPaginationBaseResponseDto<UserItem>, 'totalPage'>,
+  ) {
+    const convertedContents = ResponseUserEquippedDto.fromArray(props.contents);
+    super({ ...props, contents: convertedContents });
+    this.contents = convertedContents;
   }
 }

--- a/src/users/swagger-decorator/get-equipped-user-items.decorators.ts
+++ b/src/users/swagger-decorator/get-equipped-user-items.decorators.ts
@@ -5,7 +5,7 @@ import {
   ApiResponse,
   ApiQuery,
 } from '@nestjs/swagger';
-import { ResponseUserItemDto } from '../dtos/response-useritem.dto';
+import { ResponseUserEquippedDto } from '../dtos/response-user-equipped.dto';
 
 export function ApiGetEquippedUserItems() {
   return applyDecorators(
@@ -30,57 +30,7 @@ export function ApiGetEquippedUserItems() {
     ApiResponse({
       status: 200,
       description: '사용자 장착한 아이템 목록 조회 성공',
-      content: {
-        'application/json': {
-          example: [
-            {
-              id: 31,
-              userId: 5,
-              itemId: 39,
-              purchasedAt: '2025-02-26T07:40:01.011Z',
-              isEquipped: true,
-              item: {
-                id: 39,
-                name: '파랑 물약',
-                price: 0,
-                image: '',
-                mainCategoryId: 4,
-                subCategoryId: 8,
-              },
-            },
-            {
-              id: 21,
-              userId: 5,
-              itemId: 2,
-              purchasedAt: '2025-02-05T01:38:10.715Z',
-              isEquipped: true,
-              item: {
-                id: 2,
-                name: 'converse shoes',
-                price: 10000,
-                image: '2',
-                mainCategoryId: 1,
-                subCategoryId: 2,
-              },
-            },
-            {
-              id: 22,
-              userId: 5,
-              itemId: 3,
-              purchasedAt: '2025-02-05T01:38:10.715Z',
-              isEquipped: true,
-              item: {
-                id: 3,
-                name: 'winter setup2',
-                price: 12000,
-                image: 'winterclothes.svg',
-                mainCategoryId: 1,
-                subCategoryId: 1,
-              },
-            },
-          ],
-        },
-      },
+      type: [ResponseUserEquippedDto],
     }),
 
     ApiResponse({

--- a/src/users/swagger-decorator/get-user-items.decorators.ts
+++ b/src/users/swagger-decorator/get-user-items.decorators.ts
@@ -5,7 +5,7 @@ import {
   ApiResponse,
   ApiQuery,
 } from '@nestjs/swagger';
-import { ResponseUserItemDto } from '../dtos/response-useritem.dto';
+import { UserItemsPaginationResponseDto } from '../dtos/response-userItems-pagination.dto';
 
 export function ApiGetUserItems() {
   return applyDecorators(
@@ -42,64 +42,7 @@ export function ApiGetUserItems() {
     ApiResponse({
       status: 200,
       description: '사용자 아이템 목록 조회 성공',
-      content: {
-        'application/json': {
-          example: [
-            {
-              totalCount: 3,
-              totalPage: 1,
-              currentPage: 1,
-              contents: [
-                {
-                  id: 20,
-                  userId: 5,
-                  itemId: 1,
-                  purchasedAt: '2025-02-05T01:38:10.715Z',
-                  isEquipped: true,
-                  item: {
-                    id: 1,
-                    name: 'item1',
-                    price: 6000,
-                    image: '1',
-                    mainCategoryId: 1,
-                    subCategoryId: 1,
-                  },
-                },
-                {
-                  id: 22,
-                  userId: 5,
-                  itemId: 3,
-                  purchasedAt: '2025-02-05T01:38:10.715Z',
-                  isEquipped: true,
-                  item: {
-                    id: 3,
-                    name: 'item2',
-                    price: 12000,
-                    image: 'winterclothes.svg',
-                    mainCategoryId: 1,
-                    subCategoryId: 1,
-                  },
-                },
-                {
-                  id: 23,
-                  userId: 5,
-                  itemId: 4,
-                  purchasedAt: '2025-02-05T01:38:10.715Z',
-                  isEquipped: true,
-                  item: {
-                    id: 4,
-                    name: 'item3',
-                    price: 1000,
-                    image: '4',
-                    mainCategoryId: 1,
-                    subCategoryId: 1,
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      },
+      type: UserItemsPaginationResponseDto,
     }),
     ApiResponse({
       status: 401,


### PR DESCRIPTION
## 🔗 관련 이슈

<img width="544" alt="image" src="https://github.com/user-attachments/assets/b96999be-327f-4bf3-936a-fccf06732343" />

`GET users/me/itmes/equipped` 요청은 유저의 아이템 장착여부를 알려줍니다.

기존에는 **유저아이템+아이템** 객체배열을 전달해서 이 형태를 알려줬습니다.

**기존**
```ts
[
  {
    "id": 31,
    "userId": 5,
    "itemId": 39,
    "purchasedAt": "2025-02-26T07:40:01.011Z",
    "isEquipped": true,
    "item": {
      "id": 39,
      "name": "파랑 물약",
      "price": 0,
      "image": "",
      "mainCategoryId": 4,
      "subCategoryId": 8
    }
  }
]
```

이번 이슈를 통해 **아이템** 객체 배열에 **isEquipped** 여부만 붙여서 클라이언트에 주는 데이터를 가공해서 줍니다.

**변경**
```ts
[   
  {    
     "id": 1,
    "name": "겨울옷",
    "price": 5000,     
    "image": "Group 370.svg",     
    "isEquipped": true  
   } 
]
```


## 추가 사항

`GET users/me/itmes` 요청은 특정 유저의 아이템과 장착여부를 페이지네이션 형태로 알려줍니다.
`GET users/me/itmes/equipped` respose 데이터 구조변경처럼 해당 api 도 변경했습니다.

**변경**
```ts
{
  "totalCount": 2,
  "totalPage": 1,
  "currentPage": 1,
  "contents": [
    {
      "id": 5,
      "name": "요정-신발",
      "price": 6000,
      "image": "요정-신발.svg",
      "isEquipped": false
    },
    {
      "id": 9,
      "name": "장화1",
      "price": 5000,
      "image": "Group 360.svg",
      "isEquipped": false
    }
  ]
}
```

두 api 차이점
`GET users/me/itmes` 은 유저가 가진 모든 아이템을 페이지네이션 형태로 요청
`GET users/me/itmes/equipped` 은  유저가 장착한 아이템들 요청




## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] `GET users/me/itmes/equipped`의 resDTO 작성 및 적용
- [ ] `GET users/me/itmes`의 resDTO 작성 및 적용

## 💬리뷰 요구사항 (선택사항)
