### PR TITLE
#181의 유저아이템 response DTO에 서브카테고리 아이디 값 추가

### DIFF
--- a/src/users/dtos/response-user-equipped.dto.ts
+++ b/src/users/dtos/response-user-equipped.dto.ts
@@ -28,6 +28,12 @@ export class ResponseUserEquippedDto implements Item {
   readonly image: string;
 
   @ApiProperty({
+    example: 1,
+    description: '서브 카테고리 아이디',
+  })
+  readonly subCategoryId: number;
+
+  @ApiProperty({
     example: false,
     description: '장착 여부',
   })
@@ -38,6 +44,7 @@ export class ResponseUserEquippedDto implements Item {
     this.name = userItem.item.name;
     this.price = userItem.item.price;
     this.image = userItem.item.image;
+    this.subCategoryId = userItem.item.subCategoryId;
     this.isEquipped = userItem.isEquipped;
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

#181 

## 📝작업 내용

참조 이슈의 클라이언트에게 주는 데이터에서 subCategoryId 값을 추가로 담아서 줍니다.

## 🔍 변경 사항

- [ ] `ResponseUserEquippedDto`에 `subCategoryId`속성 추가
## 💬리뷰 요구사항 (선택사항)
