### PR TITLE
Feat/#186/ranking page get users items

### DIFF
--- a/src/ranking/dtos/ranking-pagination-res.dto.ts
+++ b/src/ranking/dtos/ranking-pagination-res.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserRankingDto } from './user-ranking.dto';
 import { OffsetPaginationBaseResponseDto } from 'src/pagination/dtos/offset-pagination-res.dto';
+import { UserItem } from 'src/users/entities/user-item.entity';
 
 export class RankingPaginationResponseDto extends OffsetPaginationBaseResponseDto<UserRankingDto> {
   @ApiProperty({
@@ -8,9 +9,11 @@ export class RankingPaginationResponseDto extends OffsetPaginationBaseResponseDt
     type: [UserRankingDto],
   })
   readonly contents: UserRankingDto[];
+  readonly equippedItems: UserItem[];
 
   constructor(props: Omit<RankingPaginationResponseDto, 'totalPage'>) {
     super(props);
     this.contents = props.contents;
+    this.equippedItems = props.equippedItems;
   }
 }

--- a/src/ranking/rankings.controller.ts
+++ b/src/ranking/rankings.controller.ts
@@ -12,7 +12,7 @@ import { ResSeasonEndTimeDto } from './dtos/res-season-end-time.dto';
 export class RankingsController {
   constructor(private readonly rankingsService: RankingsService) {}
 
-  // 랭킹 페이지 조회
+  // 랭킹 페이지 조회 (+ 각 유저의 아이템들까지 가져오기)
   @ApiRankings.findSelectedPageRankings()
   @Get()
   async findSelectedPageRankings(

--- a/src/ranking/rankings.module.ts
+++ b/src/ranking/rankings.module.ts
@@ -6,9 +6,10 @@ import { UsersCoreModule } from 'src/users/modules/users-core.module';
 import { UsersRankingsController } from './user-rankings.controller';
 import { ProgressModule } from 'src/progress/progress.module';
 import { RankingEventsListener } from './rankings.event';
+import { UserItemsModule } from 'src/users/modules/user-items.module';
 
 @Module({
-  imports: [UsersCoreModule, ProgressModule],
+  imports: [UsersCoreModule, ProgressModule, UserItemsModule],
   controllers: [RankingsController, UsersRankingsController],
   providers: [RankingsService, RankingsRepository, RankingEventsListener],
 })

--- a/src/ranking/rankings.service.ts
+++ b/src/ranking/rankings.service.ts
@@ -20,6 +20,7 @@ import utc from 'dayjs/plugin/utc';
 import { TopRankerPaginaion } from 'src/common/constants/rankings-constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { EVENT } from 'src/challenges/const/challenges.constant';
+import { UserItemsRepository } from 'src/users/repositories/user-items.repository';
 
 @Injectable()
 export class RankingsService {
@@ -27,6 +28,7 @@ export class RankingsService {
     private readonly rankingsRepository: RankingsRepository,
     private readonly usersRepository: UsersRepository,
     private readonly progressRepository: ProgressRepository,
+    private readonly userItemsRepository: UserItemsRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
@@ -41,6 +43,9 @@ export class RankingsService {
     page: number,
     limit: number,
   ): Promise<RankingPaginationResponseDto> {
+    // 유저가 가지고 있는 아이템 저장할 배열
+    const equippedItems = [];
+
     // 랭킹 정보 정렬 조건
     const orderBy = createOrderBy(sort);
 
@@ -54,11 +59,22 @@ export class RankingsService {
       orderBy,
     );
 
+    // limit만큼 반복
+    for (let i = 0; i < limit; i++) {
+      equippedItems.push(
+        await this.userItemsRepository.findEquippedUserItems({
+          userId: contents[i].id,
+          isEquipped: true,
+        }),
+      );
+    }
+
     return new RankingPaginationResponseDto({
       totalCount,
       currentPage: page,
       limit,
       contents,
+      equippedItems,
     });
   }
 

--- a/src/users/modules/user-items.module.ts
+++ b/src/users/modules/user-items.module.ts
@@ -6,5 +6,6 @@ import { UserItemsRepository } from '../repositories/user-items.repository';
 @Module({
   controllers: [UserItemsController],
   providers: [UserItemsService, UserItemsRepository],
+  exports: [UserItemsRepository],
 })
 export class UserItemsModule {}


### PR DESCRIPTION
## 🔗 관련 이슈

#186 

## 📝작업 내용

랭킹 조회시 각 유저가 장착하고 있는 아이템들을 가져옵니다.

## 🔍 변경 사항

- RankingPaginationResponseDto 변경
- 랭킹 조회시 각 유저가 장착하고 있는 아이템들을 가져옵니다.

## 💬리뷰 요구사항 (선택사항)
