### PR TITLE
이벤트 상수 시간 변경 

### DIFF
--- a/src/admin/admin.swagger.ts
+++ b/src/admin/admin.swagger.ts
@@ -4,9 +4,8 @@ import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 export const ApiAdmins = {
   loginAdmin: () => {
     return applyDecorators(
-      ApiCookieAuth('adminAccessToken'),
       ApiOperation({
-        summary: 'admin 정보 인증',
+        summary: 'admin 로그인',
       }),
       ApiResponse({
         status: 200,
@@ -18,7 +17,7 @@ export const ApiAdmins = {
     return applyDecorators(
       ApiCookieAuth('adminAccessToken'),
       ApiOperation({
-        summary: 'admin 토큰 인증',
+        summary: 'admin 토큰 인증 - admin',
       }),
       ApiResponse({
         status: 200,

--- a/src/ranking/ranking.constant.ts
+++ b/src/ranking/ranking.constant.ts
@@ -1,5 +1,5 @@
 /**
- * user의 totalCorrectAnswer 업데이트 시간 2분 (25.02.24)
- * 테스트 20초
+ * user의 totalCorrectAnswer 업데이트 시간 2분 (25.03.06)
+ * 사용자가 문제를 맞춘 이후 2분간 다시 맞추지 않을 경우 user의 총 정답수 컬럼이 업데이트 됨
  */
-export const TOTAL_CORRECT_ANSWER_UPDATE_TIME: number = 20 * 1000;
+export const TOTAL_CORRECT_ANSWER_UPDATE_TIME: number = 2 * 60 * 1000;

--- a/src/users/constants/user-hp.constant.ts
+++ b/src/users/constants/user-hp.constant.ts
@@ -5,7 +5,6 @@ export const HP_DECREASE_VALUE: number = 1;
 
 /**
  * hp refill 시간
- * 10분으로 설정 (25.02.18)
- * 테스트 환경 10초로 설정
+ * 3분으로 설정 (25.03.06)
  */
-export const HP_REFILL_TIME: number = 10 * 1000;
+export const HP_REFILL_TIME: number = 3 * 60 * 1000;

--- a/src/users/controllers/user-experience.controller.ts
+++ b/src/users/controllers/user-experience.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Body, Patch, Param, UseGuards } from '@nestjs/common';
 import { UpdateExperienceDto } from '../dtos/update-experience.dto';
 import { UserExperienceService } from '../services/user-experience.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 import { ApiGetExperience } from '../swagger-decorator/get-user-experience-decorators';
 import { ApiUpdateExperience } from '../swagger-decorator/patch-user-experience-decorators';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
@@ -23,6 +23,7 @@ export class UserExperienceController {
 
   @Patch()
   @ApiUpdateExperience()
+  @ApiExcludeEndpoint()
   @UseGuards(AuthGuard('accessToken'))
   updateExperience(
     @User() user: UserInfo,

--- a/src/users/controllers/user-point.controller.ts
+++ b/src/users/controllers/user-point.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Body, Patch, Param, UseGuards } from '@nestjs/common';
 import { UserPointService } from '../services/user-point.service';
 import { UpdatePointDto } from '../dtos/update-point.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 import { ApiUpdatePoint } from '../swagger-decorator/patch-user-point-decorators';
 import { ApiGetPoint } from '../swagger-decorator/get-user-point-decorators';
 import { AuthGuard } from '@nestjs/passport';
@@ -22,6 +22,7 @@ export class UserPointController {
 
   @Patch()
   @ApiUpdatePoint()
+  @ApiExcludeEndpoint()
   @UseGuards(AuthGuard('accessToken'))
   updatePoint(@User() user: UserInfo, @Body() updatePointData: UpdatePointDto) {
     return this.pointsService.updatePoint(user.id, updatePointData);

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -16,13 +16,14 @@ import { ResponseUserDto } from '../dtos/response-user.dto';
 import { UpdateUserDto } from '../dtos/update-user.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiGetAllUsers } from '../swagger-decorator/get-all-users-decorators';
-import { ApiGetUser } from '../swagger-decorator/get-user-decorators';
+import { ApiGetUser } from '../swagger-decorator/get-me-decorators';
 import { ApiUpdateUser } from '../swagger-decorator/patch-user-decorators';
 import { ApiDeleteUser } from '../swagger-decorator/delete-user-decorators';
 import { PositiveIntPipe } from 'src/common/pipes/positive-int/positive-int.pipe';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/get-user.decorator';
 import { UserInfo } from '../entities/user.entity';
+import { ApiAdminGetUser } from '../swagger-decorator/get-user-decorators';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @ApiTags('users')
@@ -87,7 +88,7 @@ export class UsersController {
    * @param userId
    * @returns
    */
-  @ApiGetUser()
+  @ApiAdminGetUser()
   @Get(':userId')
   @UseGuards(AuthGuard('adminAccessToken'))
   async getUser(@Param('userId', PositiveIntPipe) userId: number) {

--- a/src/users/dtos/update-experience.dto.ts
+++ b/src/users/dtos/update-experience.dto.ts
@@ -3,18 +3,6 @@ import { IsNumber, IsOptional, IsString, Length, Min } from 'class-validator';
 
 export class UpdateExperienceDto {
   @ApiProperty({
-    type: String,
-    description: '유저 닉네임',
-    example: 'gwgw123',
-    minimum: 2,
-    maximum: 10,
-  })
-  @IsOptional()
-  @IsString()
-  @Length(2, 10)
-  readonly nickname?: string;
-
-  @ApiProperty({
     required: true,
     type: Number,
     description: '경험치 증가치',

--- a/src/users/swagger-decorator/delete-user-decorators.ts
+++ b/src/users/swagger-decorator/delete-user-decorators.ts
@@ -3,9 +3,9 @@ import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export function ApiDeleteUser() {
   return applyDecorators(
-    ApiCookieAuth('adminAccessToken'),
+    ApiCookieAuth('accessToken'),
     ApiOperation({
-      summary: ' 유저 삭제',
+      summary: ' 유저 삭제 (회원 탈퇴시 사용)',
       description: ` ## 유저 삭제`,
     }),
     ApiResponse({

--- a/src/users/swagger-decorator/get-all-users-decorators.ts
+++ b/src/users/swagger-decorator/get-all-users-decorators.ts
@@ -5,7 +5,7 @@ export function ApiGetAllUsers() {
   return applyDecorators(
     ApiCookieAuth('adminAccessToken'),
     ApiOperation({
-      summary: '전체 유저 조회',
+      summary: '전체 유저 조회 - admin',
       description: `## 전체 유저 조회`,
     }),
     ApiResponse({

--- a/src/users/swagger-decorator/get-all-users-decorators.ts
+++ b/src/users/swagger-decorator/get-all-users-decorators.ts
@@ -1,8 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export function ApiGetAllUsers() {
   return applyDecorators(
+    ApiCookieAuth('adminAccessToken'),
     ApiOperation({
       summary: '전체 유저 조회',
       description: `## 전체 유저 조회`,

--- a/src/users/swagger-decorator/get-equipped-user-items.decorators.ts
+++ b/src/users/swagger-decorator/get-equipped-user-items.decorators.ts
@@ -9,7 +9,7 @@ import { ResponseUserEquippedDto } from '../dtos/response-user-equipped.dto';
 
 export function ApiGetEquippedUserItems() {
   return applyDecorators(
-    ApiCookieAuth('access-token'),
+    ApiCookieAuth('accessToken'),
     ApiOperation({
       summary: '사용자가 장착한 아이템 목록 조회',
       description:

--- a/src/users/swagger-decorator/get-me-decorators.ts
+++ b/src/users/swagger-decorator/get-me-decorators.ts
@@ -1,21 +1,27 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
-export function ApiDeleteUser() {
+export function ApiGetUser() {
   return applyDecorators(
-    ApiCookieAuth('adminAccessToken'),
+    ApiCookieAuth('accessToken'),
     ApiOperation({
-      summary: ' 유저 삭제',
-      description: ` ## 유저 삭제`,
+      summary: '단일 유저 조회',
+      description: `## 단일 유저 조회`,
     }),
     ApiResponse({
       status: 200,
-      description: '성공적으로 유저가 삭제 된 경우',
+      description: '성공적으로 단일 유저가 조회된 경우',
       content: {
         JSON: {
           example: {
-            statusCode: 204,
-            message: 'No Content',
+            id: 2,
+            nickname: 'gwgw123',
+            profileImage: null,
+            maxHealthPoint: 5,
+            level: 2,
+            experience: 30,
+            experienceForNextLevel: 60,
+            point: 200,
           },
         },
       },

--- a/src/users/swagger-decorator/get-user-decorators.ts
+++ b/src/users/swagger-decorator/get-user-decorators.ts
@@ -5,7 +5,7 @@ export function ApiAdminGetUser() {
   return applyDecorators(
     ApiCookieAuth('adminAccessToken'),
     ApiOperation({
-      summary: '단일 유저 조회',
+      summary: '단일 유저 조회 - admin',
       description: `## 단일 유저 조회`,
     }),
     ApiResponse({

--- a/src/users/swagger-decorator/get-user-decorators.ts
+++ b/src/users/swagger-decorator/get-user-decorators.ts
@@ -1,8 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
-export function ApiGetUser() {
+export function ApiAdminGetUser() {
   return applyDecorators(
+    ApiCookieAuth('adminAccessToken'),
     ApiOperation({
       summary: '단일 유저 조회',
       description: `## 단일 유저 조회`,

--- a/src/users/swagger-decorator/get-user-experience-decorators.ts
+++ b/src/users/swagger-decorator/get-user-experience-decorators.ts
@@ -1,8 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export function ApiGetExperience() {
   return applyDecorators(
+    ApiCookieAuth('accessToken'),
     ApiOperation({
       summary: '경험치 조회',
       description: `## 경험치 조회`,

--- a/src/users/swagger-decorator/get-user-point-decorators.ts
+++ b/src/users/swagger-decorator/get-user-point-decorators.ts
@@ -1,8 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export function ApiGetPoint() {
   return applyDecorators(
+    ApiCookieAuth('accessToken'),
     ApiOperation({
       summary: '포인트 조회',
       description: `## 포인트 조회`,

--- a/src/users/swagger-decorator/patch-user-decorators.ts
+++ b/src/users/swagger-decorator/patch-user-decorators.ts
@@ -5,7 +5,7 @@ export function ApiUpdateUser() {
   return applyDecorators(
     ApiCookieAuth('adminAccessToken'),
     ApiOperation({
-      summary: ' 유저 수정',
+      summary: ' 유저 수정 - admin',
       description: ` ## 유저 수정`,
     }),
     ApiResponse({

--- a/src/users/swagger-decorator/patch-user-decorators.ts
+++ b/src/users/swagger-decorator/patch-user-decorators.ts
@@ -1,8 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export function ApiUpdateUser() {
   return applyDecorators(
+    ApiCookieAuth('adminAccessToken'),
     ApiOperation({
       summary: ' 유저 수정',
       description: ` ## 유저 수정`,

--- a/src/users/swagger-decorator/patch-user-experience-decorators.ts
+++ b/src/users/swagger-decorator/patch-user-experience-decorators.ts
@@ -14,7 +14,6 @@ export function ApiUpdateExperience() {
         JSON: {
           example: {
             id: 15,
-            nickname: 'gwgw123',
             level: 1,
             experience: 30,
             experienceForNextLevel: 50,


### PR DESCRIPTION
## 🔗 관련 이슈
#188

## 📝작업 내용

이벤트 상수 시간 변경 

## 🔍 변경 사항

- 생명력 리필 시간 3분으로 변경
- 총 정답수 컬럼 업데이트 시간 2분으로 변경

## 💬리뷰 요구사항 (선택사항)
