### PR TITLE
fix/#194/랭킹 페이지내이션 로직 수정

### DIFF
--- a/src/ranking/rankings.service.ts
+++ b/src/ranking/rankings.service.ts
@@ -60,7 +60,7 @@ export class RankingsService {
     );
 
     // limit만큼 반복
-    for (let i = 0; i < limit; i++) {
+    for (let i = 0; i < contents.length; i++) {
       equippedItems.push(
         await this.userItemsRepository.findEquippedUserItems({
           userId: contents[i].id,

--- a/src/ranking/rankings.service.ts
+++ b/src/ranking/rankings.service.ts
@@ -59,7 +59,7 @@ export class RankingsService {
       orderBy,
     );
 
-    // contents.length 만큼 반복 = 해당 페이지의 보여줄 사용자 만큼
+    // contents.length 만큼 반복 = 해당 페이지에 보여줄 사용자 만큼
     for (let i = 0; i < contents.length; i++) {
       equippedItems.push(
         await this.userItemsRepository.findEquippedUserItems({

--- a/src/ranking/rankings.service.ts
+++ b/src/ranking/rankings.service.ts
@@ -59,7 +59,7 @@ export class RankingsService {
       orderBy,
     );
 
-    // limit만큼 반복
+    // contents.length 만큼 반복 = 해당 페이지의 보여줄 사용자 만큼
     for (let i = 0; i < contents.length; i++) {
       equippedItems.push(
         await this.userItemsRepository.findEquippedUserItems({


### PR DESCRIPTION
## 🔗 관련 이슈

#194

## 📝작업 내용

랭킹 페이지네이션 로직을 수정했습니다
마지막 페이지에 보여줄 사용자가 2명일때 반복문이 limit 값인 5만큼 돌아가기 때문에
참조에러가 떴었습니다. 

-> 이제 페이지에 있는 사용자 만큼 반복문이 돌아갑니다

## 🔍 변경 사항

## 💬리뷰 요구사항 (선택사항)
