### PR TITLE
로그 파일 S3에 업로드 시간 변경

### DIFF
--- a/src/common/function/time.helper.ts
+++ b/src/common/function/time.helper.ts
@@ -6,3 +6,13 @@ export function nowKST(): Date {
   const now = new Date();
   return new Date(now.getTime() + 9 * 60 * 60 * 1000); // UTC → KST 변환
 }
+
+/**
+ * 전날의 KST 시간 반환
+ * @returns
+ */
+export function yesterdayKST(): Date {
+  const now = new Date();
+  const nowKST = new Date(now.getTime() + 9 * 60 * 60 * 1000); // UTC → KST 변환
+  return new Date(nowKST.getTime() - 24 * 60 * 60 * 1000);
+}

--- a/src/daily-quests/users-daily-quests/const/users-daily-quests.const.ts
+++ b/src/daily-quests/users-daily-quests/const/users-daily-quests.const.ts
@@ -1,3 +1,4 @@
 export const DAILY_RESET = '0 15 * * *'; //// UTC 15시 === KST 00시
+export const LOG_FILE_UPLOAD_TIME = '1 15 * * *'; // = KST 00시 01분
 
 export const WEEKLY_SEASON_RESET_TIME = '0 0 0 * * 6'; // timezone 옵션을 사용해 KST 매주 토요일 00시 작동

--- a/src/s3/log-upload-scheduler.ts
+++ b/src/s3/log-upload-scheduler.ts
@@ -3,8 +3,8 @@ import { Cron } from '@nestjs/schedule';
 import * as path from 'path';
 import * as fs from 'fs';
 import { S3Service } from './s3.service';
-import { DAILY_RESET } from 'src/daily-quests/users-daily-quests/const/users-daily-quests.const';
-import { nowKST } from 'src/common/function/time.helper';
+import { LOG_FILE_UPLOAD_TIME } from 'src/daily-quests/users-daily-quests/const/users-daily-quests.const';
+import { yesterdayKST } from 'src/common/function/time.helper';
 
 @Injectable()
 export class LogUploadScheduler {
@@ -12,11 +12,12 @@ export class LogUploadScheduler {
 
   constructor(private readonly s3Service: S3Service) {}
 
-  // 매일 자정에 실행
-  @Cron(DAILY_RESET)
+  // 매일 00시 01분 에 실행
+  @Cron(LOG_FILE_UPLOAD_TIME)
   async handleLogUpload() {
     // 현재 날짜를 YYYY-MM-DD 형식으로 구함
-    const dateStr = nowKST().toISOString().split('T')[0];
+    const dateStr = yesterdayKST().toISOString().split('T')[0];
+
     const logConfigs = [
       {
         dir: path.join(process.cwd(), 'logs/info'),


### PR DESCRIPTION
## 🔗 관련 이슈

#220 

## 📝작업 내용

- 로그 파일 S3에 업로드 시간을 변경

## 🔍 변경 사항

- 죄송하게도 로그파일이 s3에 저장이 안되고 있었습니다.
00시 00분에 당일 로그 파일을 s3에 업로드 하도록 로직을 짜놨었는데, 이게 00시00분00.01초 쯤에 요청이 가다보니
16일이 끝날때 로그 파일 업로드 요청을 보내면 17일의 로그 파일을 업로드하도록 요청이 가고 있었습니다. 따라서 17일( 다음날 ) 로그파일은 찾을 수 없다는 로그만 쌓이고 있었습니다.

- 기존 00시 00분에 요청을 보내서 당일 날짜의 로그파일을 업로드하도록 요청하던것에서
-> 매일 00시 01분에 요청을 보내고 전날 날짜의 로그파일을 업로드하도록 요청합니다.

## 💬리뷰 요구사항 (선택사항)




